### PR TITLE
Removed x-padding for EpochViewer, EpochEncoder, and SpikeTrainViewer

### DIFF
--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -347,7 +347,7 @@ class EpochEncoder(ViewerBase):
             self.region.hide()
         
         self.vline.setPos(self.t)
-        self.plot.setXRange( t_start, t_stop)
+        self.plot.setXRange( t_start, t_stop, padding = 0.0)
         if self.params['view_mode']=='stacked':
             self.plot.setYRange( 0, n)
         else:

--- a/ephyviewer/epochviewer.py
+++ b/ephyviewer/epochviewer.py
@@ -146,7 +146,7 @@ class EpochViewer(BaseMultiChannelViewer):
         self.plot.addItem(self.vline)
 
         self.vline.setPos(self.t)
-        self.plot.setXRange( t_start, t_stop)
+        self.plot.setXRange( t_start, t_stop, padding = 0.0)
         self.plot.setYRange( 0, visibles.size)
 
 

--- a/ephyviewer/spiketrainviewer.py
+++ b/ephyviewer/spiketrainviewer.py
@@ -163,7 +163,7 @@ class SpikeTrainViewer(BaseMultiChannelViewer):
 
         self.vline.setPos(self.t)
         
-        self.plot.setXRange( t_start, t_stop)
+        self.plot.setXRange( t_start, t_stop, padding = 0.0)
         self.plot.setYRange( 0, visibles.size)
 
 


### PR DESCRIPTION
When a TraceViewer was vertically stacked in a window with an EpochViewer or a SpikeTrainViewer, their time axes would not align perfectly because the TraceViewer's time axis had no padding whereas the others did. This change fixes that.