### PR TITLE
Standardize opacity, color, and z-order for vline marking current time for all viewer

### DIFF
--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -240,7 +240,7 @@ class EpochEncoder(ViewerBase):
         self.plot.addItem(self.region, ignoreBounds=True)
         self.region.sigRegionChanged.connect(self.on_region_changed)
 
-        self.vline = pg.InfiniteLine(angle=90, movable=False, pen='#00FF00')
+        self.vline = pg.InfiniteLine(angle=90, movable=False, pen='#00FF00AA')
         self.plot.addItem(self.vline)
         
         self.rect_items = []

--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -241,6 +241,7 @@ class EpochEncoder(ViewerBase):
         self.region.sigRegionChanged.connect(self.on_region_changed)
 
         self.vline = pg.InfiniteLine(angle=90, movable=False, pen='#FFFFFFAA')
+        self.vline.setZValue(1) # ensure vline is above plot elements
         self.plot.addItem(self.vline)
         
         self.rect_items = []

--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -240,7 +240,7 @@ class EpochEncoder(ViewerBase):
         self.plot.addItem(self.region, ignoreBounds=True)
         self.region.sigRegionChanged.connect(self.on_region_changed)
 
-        self.vline = pg.InfiniteLine(angle=90, movable=False, pen='#00FF00AA')
+        self.vline = pg.InfiniteLine(angle=90, movable=False, pen='#FFFFFFAA')
         self.plot.addItem(self.vline)
         
         self.rect_items = []

--- a/ephyviewer/epochviewer.py
+++ b/ephyviewer/epochviewer.py
@@ -142,7 +142,7 @@ class EpochViewer(BaseMultiChannelViewer):
                 self.plot.addItem(label)
                 label.setPos(t_start, ypos+0.45)
         
-        self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#00FF00AA')
+        self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#FFFFFFAA')
         self.plot.addItem(self.vline)
 
         self.vline.setPos(self.t)

--- a/ephyviewer/epochviewer.py
+++ b/ephyviewer/epochviewer.py
@@ -143,6 +143,7 @@ class EpochViewer(BaseMultiChannelViewer):
                 label.setPos(t_start, ypos+0.45)
         
         self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#FFFFFFAA')
+        self.vline.setZValue(1) # ensure vline is above plot elements
         self.plot.addItem(self.vline)
 
         self.vline.setPos(self.t)

--- a/ephyviewer/epochviewer.py
+++ b/ephyviewer/epochviewer.py
@@ -142,7 +142,7 @@ class EpochViewer(BaseMultiChannelViewer):
                 self.plot.addItem(label)
                 label.setPos(t_start, ypos+0.45)
         
-        self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#00FF0055')
+        self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#00FF00AA')
         self.plot.addItem(self.vline)
 
         self.vline.setPos(self.t)

--- a/ephyviewer/spiketrainviewer.py
+++ b/ephyviewer/spiketrainviewer.py
@@ -106,7 +106,7 @@ class SpikeTrainViewer(BaseMultiChannelViewer):
 
     
     def initialize_plot(self):
-        self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#00FF00AA')
+        self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#FFFFFFAA')
         self.plot.addItem(self.vline)
         
         self.scatter = pg.ScatterPlotItem(size=10, pxMode = True, symbol='|')

--- a/ephyviewer/spiketrainviewer.py
+++ b/ephyviewer/spiketrainviewer.py
@@ -106,7 +106,7 @@ class SpikeTrainViewer(BaseMultiChannelViewer):
 
     
     def initialize_plot(self):
-        self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#00FF00')
+        self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#00FF00AA')
         self.plot.addItem(self.vline)
         
         self.scatter = pg.ScatterPlotItem(size=10, pxMode = True, symbol='|')

--- a/ephyviewer/spiketrainviewer.py
+++ b/ephyviewer/spiketrainviewer.py
@@ -107,6 +107,7 @@ class SpikeTrainViewer(BaseMultiChannelViewer):
     
     def initialize_plot(self):
         self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#FFFFFFAA')
+        self.vline.setZValue(1) # ensure vline is above plot elements
         self.plot.addItem(self.vline)
         
         self.scatter = pg.ScatterPlotItem(size=10, pxMode = True, symbol='|')

--- a/ephyviewer/timefreqviewer.py
+++ b/ephyviewer/timefreqviewer.py
@@ -332,7 +332,7 @@ class TimeFreqViewer(BaseMultiChannelViewer):
                 self.plots[c].addItem(image)                
                 self.images.append(image)
                 
-                vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#00FF00')
+                vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#00FF00AA')
                 self.plots[c].addItem(vline)
                 self.vlines.append(vline)
                 

--- a/ephyviewer/timefreqviewer.py
+++ b/ephyviewer/timefreqviewer.py
@@ -332,7 +332,7 @@ class TimeFreqViewer(BaseMultiChannelViewer):
                 self.plots[c].addItem(image)                
                 self.images.append(image)
                 
-                vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#00FF00AA')
+                vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#FFFFFFAA')
                 self.plots[c].addItem(vline)
                 self.vlines.append(vline)
                 

--- a/ephyviewer/timefreqviewer.py
+++ b/ephyviewer/timefreqviewer.py
@@ -333,6 +333,7 @@ class TimeFreqViewer(BaseMultiChannelViewer):
                 self.images.append(image)
                 
                 vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#FFFFFFAA')
+                vline.setZValue(1) # ensure vline is above plot elements
                 self.plots[c].addItem(vline)
                 self.vlines.append(vline)
                 

--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -369,6 +369,7 @@ class TraceViewer(BaseMultiChannelViewer):
     def initialize_plot(self):
         
         self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#FFFFFFAA')
+        self.vline.setZValue(1) # ensure vline is above plot elements
         self.plot.addItem(self.vline)
         
         self.curves = []

--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -368,7 +368,7 @@ class TraceViewer(BaseMultiChannelViewer):
     
     def initialize_plot(self):
         
-        self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#00FF00AA')
+        self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#FFFFFFAA')
         self.plot.addItem(self.vline)
         
         self.curves = []

--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -368,7 +368,7 @@ class TraceViewer(BaseMultiChannelViewer):
     
     def initialize_plot(self):
         
-        self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#00FF0055')
+        self.vline = pg.InfiniteLine(angle = 90, movable = False, pen = '#00FF00AA')
         self.plot.addItem(self.vline)
         
         self.curves = []


### PR DESCRIPTION
Some viewers had a fully opaque green vline (#00FF00). Others had a nearly transparent green vline (#00FF0055) that was difficult to see under some conditions. This commit makes vlines in all viewers have an intermediate alpha level (#00FF00AA) for best viewing.

My colleagues are always impressed when I show off ephyviewer at meetings, but they complained that they couldn't see the vline for the TraceViewer since it was too faint on the projector.