### PR TITLE
Add time zoom to other viewers, add global time zoom

### DIFF
--- a/ephyviewer/base.py
+++ b/ephyviewer/base.py
@@ -168,6 +168,9 @@ def same_param_tree(tree1, tree2):
 
 
 class Base_ParamController(QT.QWidget):
+    
+    xsize_zoomed = QT.pyqtSignal(float)
+    
     def __init__(self, parent=None, viewer=None):
         QT.QWidget.__init__(self, parent)
         
@@ -198,6 +201,7 @@ class Base_ParamController(QT.QWidget):
         factor = min(factor, 1)
         newsize = self.viewer.params['xsize']*(factor+1.)
         self.viewer.params['xsize'] = max(newsize, MIN_XSIZE)
+        self.xsize_zoomed.emit(self.viewer.params['xsize'])
 
 
 

--- a/ephyviewer/base.py
+++ b/ephyviewer/base.py
@@ -191,6 +191,14 @@ class Base_ParamController(QT.QWidget):
     def source(self):
         return self._viewer().source
 
+    def apply_xsize_zoom(self, xmove):
+        MIN_XSIZE = 1e-6
+        factor = xmove/100.
+        factor = max(factor, -0.999999999)
+        factor = min(factor, 1)
+        newsize = self.viewer.params['xsize']*(factor+1.)
+        self.viewer.params['xsize'] = max(newsize, MIN_XSIZE)
+
 
 
 class Base_MultiChannel_ParamController(Base_ParamController):

--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -252,6 +252,7 @@ class EpochEncoder(ViewerBase):
             self.plot.addItem(label_item)
             self.label_items.append(label_item)
 
+        self.viewBox.xsize_zoom.connect(self.params_controller.apply_xsize_zoom)
         
 
     def show_params_controller(self):

--- a/ephyviewer/epochviewer.py
+++ b/ephyviewer/epochviewer.py
@@ -110,7 +110,7 @@ class EpochViewer(BaseMultiChannelViewer):
 
     
     def initialize_plot(self):
-        pass
+        self.viewBox.xsize_zoom.connect(self.params_controller.apply_xsize_zoom)
     
     def refresh(self):
         xsize = self.params['xsize']

--- a/ephyviewer/mainviewer.py
+++ b/ephyviewer/mainviewer.py
@@ -25,7 +25,7 @@ orientation_to_qt={
     
 
 class MainViewer(QT.QMainWindow):
-    def __init__(self, debug=False, settings_name=None, parent=None, **navigation_params):
+    def __init__(self, debug=False, settings_name=None, parent=None, global_xsize_zoom=False, **navigation_params):
         QT.QMainWindow.__init__(self, parent)
 
         #TODO settings
@@ -38,6 +38,7 @@ class MainViewer(QT.QMainWindow):
             pyver = '.'.join(str(e) for e in sys.version_info[0:3])
             appname = 'ephyviewer'+'_py'+pyver
             self.settings = QT.QSettings(appname, self.settings_name)
+        self.global_xsize_zoom = global_xsize_zoom
         
         self.setDockNestingEnabled(True) 
         
@@ -97,6 +98,8 @@ class MainViewer(QT.QMainWindow):
         self.load_one_setting(name, widget)
         
         widget.time_changed.connect(self.on_time_changed)
+        if self.global_xsize_zoom and hasattr(widget, 'params_controller'):
+            widget.params_controller.xsize_zoomed.connect(self.on_xsize_changed)
         
 
         if len(self.viewers) ==1:
@@ -186,4 +189,3 @@ class MainViewer(QT.QMainWindow):
         event.accept()
         
         
-

--- a/ephyviewer/spiketrainviewer.py
+++ b/ephyviewer/spiketrainviewer.py
@@ -121,6 +121,9 @@ class SpikeTrainViewer(BaseMultiChannelViewer):
             self.plot.addItem(label)
             self.labels.append(label)
     
+        self.viewBox.xsize_zoom.connect(self.params_controller.apply_xsize_zoom)
+        
+    
     def refresh(self):
         xsize = self.params['xsize']
         t_start, t_stop = self.t-xsize*self._xratio , self.t+xsize*(1-self._xratio)

--- a/ephyviewer/timefreqviewer.py
+++ b/ephyviewer/timefreqviewer.py
@@ -323,6 +323,7 @@ class TimeFreqViewer(BaseMultiChannelViewer):
             if plot is not None:
                 plot.vb.doubleclicked.connect(self.show_params_controller)
                 plot.vb.ygain_zoom.connect(self.params_controller.clim_zoom)
+                # plot.vb.xsize_zoom.connect(self.params_controller.apply_xsize_zoom)
     
         self.images = []
         self.vlines = []

--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -18,7 +18,6 @@ from .datasource import InMemoryAnalogSignalSource, AnalogSignalSourceWithScatte
 import time
 import threading
 
-MIN_XSIZE = 1e-6
 
 
 default_params = [
@@ -187,12 +186,6 @@ class TraceViewer_ParamController(Base_MultiChannel_ParamController):
         self.viewer.refresh()
         #~ print('apply_ygain_zoom', factor_ratio)#, 'self.ygain_factor', self.ygain_factor)
         
-    def apply_xsize_zoom(self, xmove):
-        factor = xmove/100.
-        factor = max(factor, -0.999999999)
-        factor = min(factor, 1)
-        newsize = self.viewer.params['xsize']*(factor+1.)
-        self.viewer.params['xsize'] = max(newsize, MIN_XSIZE)
 
 
 


### PR DESCRIPTION
Code for dragging the right mouse button to adjust `xsize` (time zoom) was confined to `TraceViewer`. The first commit (c78fcb7) moves that code to base classes and adds signal connections for `EpochEncoder`, `EpochViewer`, and `SpikeTrainViewer`. Time zoom could be added to `TimeFreqViewer` (see commented out code), but performance is very poor, so this was not added.

In the second commit (f6179b2), `MainViewer` has a new boolean option called `global_xsize_zoom` (default False). When True, dragging the right mouse button to adjust the `xsize` (time zoom) in one viewer will make the same adjustment simultaneously in all viewers.