### PR TITLE
Improve label legibility

### DIFF
--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -248,7 +248,7 @@ class EpochEncoder(ViewerBase):
         self.label_items = []
         for i, label in enumerate(self.source.possible_labels):
             color = self.by_label_params['label'+str(i), 'color']
-            label_item = pg.TextItem(label, color=color, anchor=(0, 0.5), border=None, fill=pg.mkColor((128,128,128, 120)))
+            label_item = pg.TextItem(label, color=color, anchor=(0, 0.5), border=None, fill=pg.mkColor((34,34,34, 221)))
             self.plot.addItem(label_item)
             self.label_items.append(label_item)
 

--- a/ephyviewer/epochviewer.py
+++ b/ephyviewer/epochviewer.py
@@ -138,7 +138,7 @@ class EpochViewer(BaseMultiChannelViewer):
 
             if self.params['display_labels']:
                 label_name = '{}: {}'.format(chan, self.source.get_channel_name(chan=chan))
-                label = pg.TextItem(label_name, color=color, anchor=(0, 0.5), border=None, fill=pg.mkColor((128,128,128, 180)))
+                label = pg.TextItem(label_name, color=color, anchor=(0, 0.5), border=None, fill=pg.mkColor((34,34,34, 221)))
                 self.plot.addItem(label)
                 label.setPos(t_start, ypos+0.45)
         

--- a/ephyviewer/spiketrainviewer.py
+++ b/ephyviewer/spiketrainviewer.py
@@ -117,7 +117,7 @@ class SpikeTrainViewer(BaseMultiChannelViewer):
         for c in range(self.source.nb_channel):
             label_name = '{}: {}'.format(c, self.source.get_channel_name(chan=c))
             color = self.by_channel_params.children()[c].param('color').value()
-            label = pg.TextItem(label_name, color=color, anchor=(0, 0.5), border=None, fill=pg.mkColor((128,128,128, 180)))
+            label = pg.TextItem(label_name, color=color, anchor=(0, 0.5), border=None, fill=pg.mkColor((34,34,34, 221)))
             self.plot.addItem(label)
             self.labels.append(label)
     

--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -382,7 +382,7 @@ class TraceViewer(BaseMultiChannelViewer):
             self.curves.append(curve)
             
             ch_name = '{}: {}'.format(c, self.source.get_channel_name(chan=c))
-            label = pg.TextItem(ch_name, color=color, anchor=(0, 0.5), border=None, fill=pg.mkColor((128,128,128, 180)))
+            label = pg.TextItem(ch_name, color=color, anchor=(0, 0.5), border=None, fill=pg.mkColor((34,34,34, 221)))
             
             self.plot.addItem(label)
             self.channel_labels.append(label)


### PR DESCRIPTION
For most of the non-default color schemes (i.e., whenever the colors were not bright green), contrast between label text and the label background or plot contents was poor. This commit both darkens and increases the opacity of the label backgrounds, making the labels much easier to read for non-default color schemes.