### PR TITLE
Add scatter_size as an adjustable parameter to TraceViewer

### DIFF
--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -316,7 +316,7 @@ class TraceViewer(BaseMultiChannelViewer):
     
     request_data = QT.pyqtSignal(float, float, float, object, object, object, object)
     
-    def __init__(self, scatter_size=None, **kargs):
+    def __init__(self, **kargs):
         BaseMultiChannelViewer.__init__(self, **kargs)
 
         self.make_params()
@@ -341,9 +341,6 @@ class TraceViewer(BaseMultiChannelViewer):
         self.request_data.connect(self.datagrabber.on_request_data)
         
         self.params.param('xsize').setLimits((0, np.inf))
-        
-        if scatter_size is not None and scatter_size > 0:
-            self.params['scatter_size'] = scatter_size
         
     
     @classmethod

--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -27,6 +27,7 @@ default_params = [
     {'name': 'xsize', 'type': 'float', 'value': 3., 'step': 0.1},
     {'name': 'ylim_max', 'type': 'float', 'value': 10.},
     {'name': 'ylim_min', 'type': 'float', 'value': -10.},
+    {'name': 'scatter_size', 'type': 'float', 'value': 10.,  'limits': (0,np.inf)},
     {'name': 'scale_mode', 'type': 'list', 'value': 'real_scale', 
         'values':['real_scale', 'same_for_all', 'by_channel'] },
     {'name': 'background_color', 'type': 'color', 'value': 'k'},
@@ -315,7 +316,7 @@ class TraceViewer(BaseMultiChannelViewer):
     
     request_data = QT.pyqtSignal(float, float, float, object, object, object, object)
     
-    def __init__(self, **kargs):
+    def __init__(self, scatter_size=None, **kargs):
         BaseMultiChannelViewer.__init__(self, **kargs)
 
         self.make_params()
@@ -340,6 +341,9 @@ class TraceViewer(BaseMultiChannelViewer):
         self.request_data.connect(self.datagrabber.on_request_data)
         
         self.params.param('xsize').setLimits((0, np.inf))
+        
+        if scatter_size is not None and scatter_size > 0:
+            self.params['scatter_size'] = scatter_size
         
     
     @classmethod
@@ -394,7 +398,7 @@ class TraceViewer(BaseMultiChannelViewer):
             self.channel_offsets_line.append(offset_line)
         
         if self.source.with_scatter:
-            self.scatter = pg.ScatterPlotItem(size=10, pxMode = True)
+            self.scatter = pg.ScatterPlotItem(size=self.params['scatter_size'], pxMode = True)
             self.plot.addItem(self.scatter)
                 
         
@@ -412,6 +416,9 @@ class TraceViewer(BaseMultiChannelViewer):
             if param.name()=='antialias':
                 for curve in self.curves:
                     curve.updateData(antialias=self.params['antialias'])
+            if param.name()=='scatter_size':
+                if self.source.with_scatter:
+                    self.scatter.setSize(self.params['scatter_size'])
             
         
         self.refresh()


### PR DESCRIPTION
The new `scatter_size` param for `TraceViewer` controls the size of scatter plot points (drawn only when the source is an `AnalogSignalSourceWithScatter`). The parameter can be set at initialization (`TraceViewer(..., scatter_size=5)`) and using the global options window (double click on trace window).