### PR TITLE
Fixes for xsize zoom

### DIFF
--- a/ephyviewer/base.py
+++ b/ephyviewer/base.py
@@ -199,7 +199,7 @@ class Base_ParamController(QT.QWidget):
     def apply_xsize_zoom(self, xmove):
         MIN_XSIZE = 1e-6
         factor = xmove/100.
-        factor = max(factor, -0.999999999)
+        factor = max(factor, -0.5)
         factor = min(factor, 1)
         newsize = self.viewer.params['xsize']*(factor+1.)
         self.viewer.params['xsize'] = max(newsize, MIN_XSIZE)

--- a/ephyviewer/mainviewer.py
+++ b/ephyviewer/mainviewer.py
@@ -104,7 +104,7 @@ class MainViewer(QT.QMainWindow):
         
         widget.time_changed.connect(self.on_time_changed)
         if self.global_xsize_zoom and hasattr(widget, 'params_controller'):
-            widget.params_controller.xsize_zoomed.connect(self.on_xsize_changed)
+            widget.params_controller.xsize_zoomed.connect(self.set_xsize)
         
         if hasattr(widget.source, 't_start'):
             # quick fix for DataFrameView should be removed with betetr solution


### PR DESCRIPTION
I find that the xsize zoom feature is too sensitive when zooming in. Often I will move a little too quickly and the xsize will shrink instantly to a microsecond. The first of these commits prevents that from happening by slowing the xsize reduction rate. I think it's still plenty fast. The zoom out rate (xsize increasing) is unchanged.

The second commit fixes the `global_xsize_zoom` option, which previously did not update the xsize spinbox in the navigation widget.