### PR TITLE
Remove "s" suffixes from navigation spinboxes for time and xsize

### DIFF
--- a/ephyviewer/navigation.py
+++ b/ephyviewer/navigation.py
@@ -129,6 +129,7 @@ class NavigationToolBar(QT.QWidget) :
 
         
         if show_spinbox:
+            h.addWidget(QT.QLabel('Time (s):'))
             self.spinbox_time =pg.SpinBox(decimals = 8, bounds = (-np.inf, np.inf),step = 0.05, siPrefix=False, suffix='', int=False)
             h.addWidget(self.spinbox_time)
             #trick for separator
@@ -146,7 +147,7 @@ class NavigationToolBar(QT.QWidget) :
             h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
         
         if show_global_xsize:
-            h.addWidget(QT.QLabel('xsize'))
+            h.addWidget(QT.QLabel('Time width (s):'))
             self.spinbox_xsize =pg.SpinBox(value=3., decimals = 8, bounds = (0.001, np.inf),step = 0.1, siPrefix=False, suffix='', int=False)
             h.addWidget(self.spinbox_xsize)
             #~ self.spinbox_xsize.valueChanged.connect(self.on_spinbox_xsize_changed)
@@ -155,10 +156,10 @@ class NavigationToolBar(QT.QWidget) :
             h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
         
         if show_auto_scale:
-            but = QT.PushButton('auto-scale')
+            but = QT.PushButton('Auto scale')
             h.addWidget(but)
             but.clicked.connect(self.auto_scale_requested.emit)
-            h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
+            #~ h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
         
         h.addStretch()
 

--- a/ephyviewer/navigation.py
+++ b/ephyviewer/navigation.py
@@ -129,7 +129,7 @@ class NavigationToolBar(QT.QWidget) :
 
         
         if show_spinbox:
-            self.spinbox_time =pg.SpinBox(decimals = 8, bounds = (-np.inf, np.inf),step = 0.05, siPrefix=False, suffix='s', int=False)
+            self.spinbox_time =pg.SpinBox(decimals = 8, bounds = (-np.inf, np.inf),step = 0.05, siPrefix=False, suffix='', int=False)
             h.addWidget(self.spinbox_time)
             #trick for separator
             h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
@@ -147,7 +147,7 @@ class NavigationToolBar(QT.QWidget) :
         
         if show_global_xsize:
             h.addWidget(QT.QLabel('xsize'))
-            self.spinbox_xsize =pg.SpinBox(value=3., decimals = 8, bounds = (0.001, np.inf),step = 0.1, siPrefix=False, suffix='s', int=False)
+            self.spinbox_xsize =pg.SpinBox(value=3., decimals = 8, bounds = (0.001, np.inf),step = 0.1, siPrefix=False, suffix='', int=False)
             h.addWidget(self.spinbox_xsize)
             #~ self.spinbox_xsize.valueChanged.connect(self.on_spinbox_xsize_changed)
             self.spinbox_xsize.valueChanged.connect(self.xsize_changed.emit)


### PR DESCRIPTION
pyqtgraph allows unit abbreviations to be appended to spinboxes as suffixes. However, this makes changing the numbers in the spinboxes more difficult. For the time and xsize spinboxes, the "s" for seconds cannot be temporarily deleted while typing in the box. If the cursor is placed behind the suffix, the backspace key will not work. The user has to be very careful to place their cursor in front of the "s" before they can make changes.

The first of these commits drops the suffixes entirely. The second commit adds properly formatted labels for the spinboxes (and the auto scale button), including indicators of the time units.