### PR TITLE
Shortcuts for changing the navigation step size

### DIFF
--- a/ephyviewer/navigation.py
+++ b/ephyviewer/navigation.py
@@ -125,6 +125,13 @@ class NavigationToolBar(QT.QWidget) :
             prev_step_shortcut.activated.connect(self.prev_step)
             next_step_shortcut.activated.connect(self.next_step)
 
+            # add Shift + arrow key shortcuts for changing step size
+            increase_step_shortcut = QT.QShortcut(self)
+            decrease_step_shortcut = QT.QShortcut(self)
+            increase_step_shortcut.setKey('Shift+Right')
+            decrease_step_shortcut.setKey('Shift+Left')
+            increase_step_shortcut.activated.connect(self.increase_step)
+            decrease_step_shortcut.activated.connect(self.decrease_step)
         
 
         
@@ -221,6 +228,14 @@ class NavigationToolBar(QT.QWidget) :
     def next_step(self):
         t = self.t +  self.step_size
         self.seek(t)
+    
+    def increase_step(self):
+        new_index = max(self.combo_step.currentIndex()-1, 0)
+        self.combo_step.setCurrentIndex(new_index)
+    
+    def decrease_step(self):
+        new_index = min(self.combo_step.currentIndex()+1, self.combo_step.count()-1)
+        self.combo_step.setCurrentIndex(new_index)
     
     def on_scroll_time_changed(self, pos):
         t = pos/1000.*(self.t_stop - self.t_start)+self.t_start

--- a/ephyviewer/navigation.py
+++ b/ephyviewer/navigation.py
@@ -95,7 +95,7 @@ class NavigationToolBar(QT.QWidget) :
             play_pause_shortcut.setKey(' ')
             play_pause_shortcut.activated.connect(self.on_play_pause_shortcut)
         
-        self.steps = ['60s','10s', '1s', '100ms', '50ms', '5ms' ]
+        self.steps = ['60 s', '10 s', '1 s', '100 ms', '50 ms', '5 ms', '1 ms', '200 us']
         
         if show_step:
             but = QT.QPushButton('<')
@@ -217,6 +217,8 @@ class NavigationToolBar(QT.QWidget) :
 
         if text.endswith('ms'):
             self.step_size = float(text[:-2])*1e-3
+        elif text.endswith('us'):
+            self.step_size = float(text[:-2])*1e-6
         else:
             self.step_size = float(text[:-1])
         #~ print('self.step_size', self.step_size)


### PR DESCRIPTION
Convenient key bindings for stepping through time with the left and right arrow keys already exist. The first commit adds new key bindings for increasing (Shift+right arrow) and decreasing (Shift+left arrow) the step size. The second commit adds a couple smaller step sizes to the list.