### PR TITLE
Add line-width option to TraceViewer

### DIFF
--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -35,6 +35,7 @@ default_params = [
     {'name': 'display_offset', 'type': 'bool', 'value': False},
     {'name': 'antialias', 'type': 'bool', 'value': False},    
     {'name': 'decimation_method', 'type': 'list', 'value': 'min_max', 'values': ['min_max', 'mean', 'pure_decimate',  ]},
+    {'name': 'line_width', 'type': 'float', 'value': 1., 'limits': (0, np.inf)},
     ]
 
 default_by_channel_params = [ 
@@ -466,7 +467,7 @@ class TraceViewer(BaseMultiChannelViewer):
             self.curves[c].setData(times_curves, dict_curves[c])
             
             color = self.by_channel_params['ch{}'.format(c), 'color']
-            self.curves[c].setPen(color)
+            self.curves[c].setPen(color=color, width=self.params['line_width'])
             
             if self.params['display_labels']:
                 self.channel_labels[c].show()


### PR DESCRIPTION
The lines in the TraceViewer can be difficult to see under some conditions, such as when using a projector during a presentation. This commit adds a new option for adjusting the line widths in the TraceViewer.

Unfortunately, any value greater than 1.0 pixel has _extremely_ poor performance on my system, making it infeasible to play through the data with a greater line width. This feature isn't useful for that, but it may be useful to others for static displays, such as screenshots.

I haven't investigated the cause of the poor performance. I'd speculate that the problem is with pyqtgraph, not ephyviewer. Perhaps this can be optimized somehow.