### PR TITLE
Fix for video streams lacking start_time

### DIFF
--- a/ephyviewer/datasource/video.py
+++ b/ephyviewer/datasource/video.py
@@ -269,7 +269,7 @@ class FrameGrabber:
 
         index, first_frame = next(self.next_frame())
         
-        self.stream.seek(self.stream.start_time)
+        self.stream.seek(self.stream.start_time or 0)
         
         # find the pts of the first frame
         index, first_frame = next(self.next_frame())


### PR DESCRIPTION
Some videos (e.g. screen recordings made with old versions of QuickTime Player) have stream.start_time = None, which causes seek to fail. This commit provides 0 as a fallback offset parameter for seek.