### PR TITLE
Address PyAV deprecation warnings

### DIFF
--- a/ephyviewer/datasource/video.py
+++ b/ephyviewer/datasource/video.py
@@ -152,7 +152,12 @@ class FrameGrabber:
             if original_target_frame_pts is None:
                 original_target_frame_pts = target_pts
             
-            self.stream.seek(int(target_pts))
+            try:
+                # PyAV >= 6.1.0
+                self.file.seek(int(target_pts), stream=self.stream)
+            except TypeError:
+                # PyAV < 6.1.0
+                self.stream.seek(int(target_pts))
             
             frame_index = None
             
@@ -236,7 +241,12 @@ class FrameGrabber:
             target_sec = seek_frame * 1/ self.rate
             target_pts = int(target_sec / self.time_base) + self.start_time
             
-            self.stream.seek(int(target_pts))
+            try:
+                # PyAV >= 6.1.0
+                self.file.seek(int(target_pts), stream=self.stream)
+            except TypeError:
+                # PyAV < 6.1.0
+                self.stream.seek(int(target_pts))
             
             frame_index = None
             
@@ -269,7 +279,12 @@ class FrameGrabber:
 
         index, first_frame = next(self.next_frame())
         
-        self.stream.seek(self.stream.start_time or 0)
+        try:
+            # PyAV >= 6.1.0
+            self.file.seek(self.stream.start_time or 0, stream=self.stream)
+        except TypeError:
+            # PyAV < 6.1.0
+            self.stream.seek(self.stream.start_time or 0)
         
         # find the pts of the first frame
         index, first_frame = next(self.next_frame())

--- a/ephyviewer/datasource/video.py
+++ b/ephyviewer/datasource/video.py
@@ -46,7 +46,7 @@ class FrameGrabber:
     """
     
     this is taken from pyav example here but without QT stuff.
-    https://github.com/mikeboers/PyAV/blob/master/examples/frame_seek_example.py
+    https://github.com/mikeboers/PyAV/blob/master/scratchpad/frame_seek_example.py
     """
     
     def __init__(self):

--- a/ephyviewer/videoviewer.py
+++ b/ephyviewer/videoviewer.py
@@ -226,7 +226,12 @@ class VideoViewer(BaseMultiChannelViewer):
         #~ print('update_frame', video_index, frame)
         
         #TODO : find better solution!!!! to avoid copy
-        img = frame.to_nd_array(format='rgb24')
+        try:
+            # PyAV >= 0.5.3
+            img = frame.to_ndarray(format='rgb24')
+        except AttributeError:
+            # PyAV < 0.5.3
+            img = frame.to_nd_array(format='rgb24')
         img = img.swapaxes(0,1)[:,::-1,:]
         #~ print(img.shape, img.dtype)
         self.images[video_index].setImage(img)


### PR DESCRIPTION
Since PyAV 0.5.3 (Oct 2018) and 6.1.0 (Nov 2018), ephyviewer's video source and video viewer classes have generated deprecation warnings. This PR updates the function calls so that the deprecation warnings are no longer raised.

Because PyAV's API changes were not made backwards compatible, the changes introduced here to ephyviewer are wrapped in a `try` statement to allow ephyviewer to remain backwards compatible with older versions of PyAV.