### PR TITLE
Fix for seeking non-existent video frames beyond end of video

### DIFF
--- a/ephyviewer/datasource/video.py
+++ b/ephyviewer/datasource/video.py
@@ -99,7 +99,9 @@ class FrameGrabber:
     def get_frame(self, target_frame):
         #~ print('get_frame', target_frame)
         
-        if self.last_frame_index is None or \
+        if target_frame >= self.nb_frames:
+            frame = self.get_frame_absolut_seek(self.nb_frames)
+        elif self.last_frame_index is None or \
                 (target_frame < self.last_frame_index) or \
                 (target_frame > self.last_frame_index + 300):
             frame = self.get_frame_absolut_seek(target_frame)


### PR DESCRIPTION
`get_frame` was sometimes called with a `target_frame` greater than the last frame index. This could occur when dragging the navigation slider all the way to the end, or when trying to step beyond the end of the video. This caused `get_frame_absolut_seek` to spend 250 iterations in its `reseek` loop, and the video would freeze for many seconds until this loop completed.

This commit adds a check to `get_frame`: if the `target_frame` exceeds the final frame index, the final frame is fetched instead.