### PR TITLE
Ensure time_to_frame_index always returns the frame preceding t

### DIFF
--- a/ephyviewer/datasource/video.py
+++ b/ephyviewer/datasource/video.py
@@ -348,10 +348,12 @@ class MultiVideoFileSource( BaseDataSource):
     
     def time_to_frame_index(self, i, t):
         
+        # if t is between frames, both methods return
+        # the index of the frame *preceding* t
         if self.video_times is None:
             frame_index = int((t-self.t_starts[i])*self.rates[i])
         else:
-            frame_index = np.searchsorted(self.video_times[i], t)
+            frame_index = np.searchsorted(self.video_times[i], t, side='right') - 1
         
         return frame_index
 


### PR DESCRIPTION
`MultiVideoFileSource.time_to_frame_index` can determine the frame index in one of two ways: (1) The timing of each frame can be inferred from the video rate and start time (assuming regular timing), or (2) arbitrary frame timing can be explicitly provided in `video_times`.

In the first case, the frame index is computed as
```python
frame_index = int((t-self.t_starts[i])*self.rates[i])
```
__This has the effect of always rounding down:__ If `t` is between frames, the index of the frame __before__ `t` will be returned.

In the second case, the frame index is computed as
```python
frame_index = np.searchsorted(self.video_times[i], t)
```
__This has the effect of always rounding up:__ If `t` is between frames, the index of the frame __after__ `t` will be returned. This is because [`searchsorted`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.searchsorted.html) gives the index where `t` could be inserted into `video_times` to maintain order. For example, with `video_times = [0, 1, 2]` and `t = 0.5`, the result would be 1.

This PR changes the second method so that it behaves like the first and returns the index of the frame before `t`:
```python
frame_index = np.searchsorted(self.video_times[i], t, side='right') - 1
```
Subtracting 1 corrects for the off-by-one error, and `side='right'` ensures that if `t` is _not_ between frames, but corresponds exactly to a frame time, then the correspond frame index is returned.

With this change, one could use
```python
video_times = t_start + np.arange(nb_frames)/rate
```
with the second method and obtain the same result as the first method (which is what motivated this whole endeavor in the first place!).