### PR TITLE
Fix for seeking non-existent video frames before start of video

### DIFF
--- a/ephyviewer/datasource/video.py
+++ b/ephyviewer/datasource/video.py
@@ -99,14 +99,16 @@ class FrameGrabber:
     def get_frame(self, target_frame):
         #~ print('get_frame', target_frame)
         
-        if target_frame >= self.nb_frames:
+        if target_frame == self.last_frame_index:
+            frame = self.last_frame
+        elif target_frame < 0:
+            frame = self.get_frame_absolut_seek(0)
+        elif target_frame >= self.nb_frames:
             frame = self.get_frame_absolut_seek(self.nb_frames)
         elif self.last_frame_index is None or \
                 (target_frame < self.last_frame_index) or \
                 (target_frame > self.last_frame_index + 300):
             frame = self.get_frame_absolut_seek(target_frame)
-        elif target_frame == self.last_frame_index:
-            frame = self.last_frame
         else:
             frame = None
             for i, (frame_index, next_frame) in enumerate(self.next_frame()):


### PR DESCRIPTION
`get_frame` was sometimes called with a negative `target_frame`. This could occur when the video's `t_start` was positive, or if `video_times` began with positive values. Like the bug fixed by 535ba9a, this caused `get_frame_absolut_seek` to spend 250 iterations in its `reseek` loop, and the video would freeze for many seconds until this loop completed.

This commit adds a check to `get_frame`: if the `target_frame` is negative, the first frame is fetched instead.

The commit also moves the comparison to `last_frame_index` to the beginning for optimization.