### PR TITLE
Fix for standalone crash when signals start after t=2.1

### DIFF
--- a/ephyviewer/mainviewer.py
+++ b/ephyviewer/mainviewer.py
@@ -217,11 +217,11 @@ def compose_mainviewer_from_sources(sources, mainviewer=None):
         view = TraceViewer(source=sig_source, name='signal {}'.format(i))
         view.params['scale_mode'] = 'same_for_all'
         view.params['display_labels'] = True
-        view.auto_scale()
         if i==0:
             mainviewer.add_view(view)
         else:
             mainviewer.add_view(view, tabify_with='signal {}'.format(i-1))
+        view.auto_scale()
         
 
     for i, spike_source in enumerate(sources['spike']):

--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -139,7 +139,7 @@ class TraceViewer_ParamController(Base_MultiChannel_ParamController):
         offsets = np.zeros(self.viewer.source.nb_channel)
         nb_visible = np.sum(self.visible_channels)
         #~ self.ygain_factor = 1
-        if self.viewer.last_sigs_chunk is not None:
+        if self.viewer.last_sigs_chunk is not None and self.viewer.last_sigs_chunk is not []:
             self.estimate_median_mad()
 
             if scale_mode=='real_scale':


### PR DESCRIPTION
The standalone app would crash if the signals did not begin at t=0, but instead started after t=2.1. This occurred because `compose_mainviewer_from_sources` would try to `auto_scale` before the first signal was added to the window. Before any viewers are added to the window, the time is initially set to 0 with `xsize` = 3. Thus the right edge of the view is t=2.0999. Attempting to `auto_scale` a signal that has no data points within the window causes a crash because `get_chunk` returns an empty list. `compute_rescale` checked that the list was not None, but not that it wasn't empty, so it attempted to compute statistics on an empty list.

This commit fixes the issue by first catching the empty list case, and second by having the standalone app auto scale only after the trace viewer has been added to the window, which triggers the time to shift to the signal's `t_start`, allowing `get_chunk` to actually return the beginning of the signal.