### PR TITLE
Fix poor performance when TraceViewer's line_width > 1.0

### DIFF
--- a/ephyviewer/base.py
+++ b/ephyviewer/base.py
@@ -99,14 +99,14 @@ class BaseMultiChannelViewer(ViewerBase):
                                     type='group', children=[self.params, self.by_channel_params])
         self.all_params.sigTreeStateChanged.connect(self.on_param_change)
 
-    def set_layout(self):
+    def set_layout(self, useOpenGL=None):
         # layout
         self.mainlayout = QT.QVBoxLayout()
         self.setLayout(self.mainlayout)
 
         self.viewBox = MyViewBox()
 
-        self.graphicsview  = pg.GraphicsView()#useOpenGL = True)
+        self.graphicsview  = pg.GraphicsView(useOpenGL=useOpenGL)
         self.mainlayout.addWidget(self.graphicsview)
 
         self.plot = pg.PlotItem(viewBox=self.viewBox)

--- a/ephyviewer/myqt.py
+++ b/ephyviewer/myqt.py
@@ -48,3 +48,8 @@ else:
 
 if QT is not None:
     from pyqtgraph import mkQApp
+
+    # without this, pyqtgraph's performance is terrible if the user sets
+    # TraceViewer's line_width to any value greater than 1.0
+    import pyqtgraph as pg
+    pg.setConfigOptions(useOpenGL=True)

--- a/ephyviewer/myqt.py
+++ b/ephyviewer/myqt.py
@@ -48,8 +48,3 @@ else:
 
 if QT is not None:
     from pyqtgraph import mkQApp
-
-    # without this, pyqtgraph's performance is terrible if the user sets
-    # TraceViewer's line_width to any value greater than 1.0
-    import pyqtgraph as pg
-    pg.setConfigOptions(useOpenGL=True)

--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -321,11 +321,16 @@ class TraceViewer(BaseMultiChannelViewer):
 
     request_data = QT.pyqtSignal(float, float, float, object, object, object, object)
 
-    def __init__(self, **kargs):
+    def __init__(self, useOpenGL=None, **kargs):
         BaseMultiChannelViewer.__init__(self, **kargs)
 
         self.make_params()
-        self.set_layout()
+
+        # useOpenGL=True eliminates the extremely poor performance associated
+        # with TraceViewer's line_width > 1.0, but it also degrades overall
+        # performance somewhat and is reportedly unstable
+        self.set_layout(useOpenGL=useOpenGL)
+
         self.make_param_controller()
 
         self.viewBox.doubleclicked.connect(self.show_params_controller)


### PR DESCRIPTION
Fixes #34.

This performance issue clearly isn't confined to ephyviewer, as the same issue has been [reported for pyqtgraph](https://github.com/pyqtgraph/pyqtgraph/issues/533) and [Qt itself](http://www.qcustomplot.com/index.php/support/forum/1008). The solution I'm trying in this PR was proposed by @campagnola here: https://github.com/pyqtgraph/pyqtgraph/issues/533#issuecomment-388932019.

I don't want to merge this immediately. I'd like to try it out for a couple days to see if there are any new problems. I don't really understand the full implications of enabling OpenGL, and [the pyqtgraph docs here](http://www.pyqtgraph.org/documentation/config_options.html) leaves me feeling a little nervous; "`useOpenGL | bool | False | Enable OpenGL in GraphicsView. This can have unpredictable effects on stability and performance.`"

Furthermore, @campagnola said it didn't work for him. It works for me flawlessly on my laptop, <strike>though I just discovered that the original performance issue isn't present at all on my desktop computer, which was very unexpected.</strike> I want to spend some more time testing all this stuff.

@samuelgarcia, if you could give this a quick test in your work environment, that would boost my confidence that it's OK. Just increase the `line_width` parameter for TraceViewer and compare the refresh performance before and after the fix. The difference should be pretty dramatic.