### PR TITLE
Fix TraceViewer drawing incomplete curves when zoomed in

### DIFF
--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -207,7 +207,7 @@ class DataGrabber(QT.QObject):
 
     def get_data(self, t, t_start, t_stop, gains, offsets, visibles, decimation_method):
 
-        i_start, i_stop = self.source.time_to_index(t_start), self.source.time_to_index(t_stop)
+        i_start, i_stop = self.source.time_to_index(t_start), self.source.time_to_index(t_stop) + 2
         #~ print(t_start, t_stop, i_start, i_stop)
 
         ds_ratio = (i_stop - i_start)//self._max_point + 1


### PR DESCRIPTION
For TraceViewer, after zooming time in such that only a few points are visible, the curves would end before reaching the right edge of the viewer. If the user zoomed in more, the ends of the lines would eventually travel off the left edge of the viewer and cease to be visible. This was caused by `DataGrabber.get_data` grabbing too few points when it needed to grab some extras outside the visible plot range to ensure curves continued across the entire plotted range. This commit fixes this so that the curves continue across the viewer no matter how much the user zooms in time.

I expected I would need to add 1 to `i_stop`, not 2, but I can tell you that, empirically, it required 2. I don't know why exactly! `BaseAnalogSignalSource.time_to_index` rounds down and returns the last index before the requested time, so that's part of it. Maybe there is a second rounding down that I missed.