### PR TITLE
Don't adjust offsets in apply_ygain_zoom for TraceViewer

### DIFF
--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -183,7 +183,7 @@ class TraceViewer_ParamController(Base_MultiChannel_ParamController):
             #TODO ylims
         else :
             #~ self.ygain_factor *= factor_ratio
-            if not hasattr(self, 'self.signals_med'):
+            if not hasattr(self, 'signals_med'):
                 self.estimate_median_mad()
             self.offsets = self.offsets + self.signals_med*self.gains * (1-factor_ratio)
             self.gains = self.gains * factor_ratio

--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -183,7 +183,10 @@ class TraceViewer_ParamController(Base_MultiChannel_ParamController):
             #TODO ylims
         else :
             #~ self.ygain_factor *= factor_ratio
+            if not hasattr(self, 'self.signals_med'):
+                self.estimate_median_mad()
             self.gains = self.gains * factor_ratio
+            self.offsets = self.offsets + self.signals_med*self.gains * (1-factor_ratio)
 
         self.viewer.all_params.blockSignals(False)
 

--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -185,8 +185,8 @@ class TraceViewer_ParamController(Base_MultiChannel_ParamController):
             #~ self.ygain_factor *= factor_ratio
             if not hasattr(self, 'self.signals_med'):
                 self.estimate_median_mad()
-            self.gains = self.gains * factor_ratio
             self.offsets = self.offsets + self.signals_med*self.gains * (1-factor_ratio)
+            self.gains = self.gains * factor_ratio
 
         self.viewer.all_params.blockSignals(False)
 

--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -183,10 +183,7 @@ class TraceViewer_ParamController(Base_MultiChannel_ParamController):
             #TODO ylims
         else :
             #~ self.ygain_factor *= factor_ratio
-            if not hasattr(self, 'self.signals_med'):
-                self.estimate_median_mad()
             self.gains = self.gains * factor_ratio
-            self.offsets = self.offsets + self.signals_med*self.gains * (1-factor_ratio)
 
         self.viewer.all_params.blockSignals(False)
 


### PR DESCRIPTION
The objective of the code removed by this commit was to keep the medians of the signals fixed in place as ygain was zoomed in or out under `by_channel` or `same_for_all` scale modes. However, because the median is only estimated from a randomly selected subset of samples and also changes from chunk to chunk, this makes ygain zoom in these modes a non-reversible operation, i.e., zooming in and then zooming out does not return you to the same configuration. Instead, the offsets of the signals can drift away from their original locations and the signals can even move out of view, like this:

![ygain_zoom_with_offsets](https://user-images.githubusercontent.com/241234/58771442-31d81c00-8582-11e9-88a2-9343a7c879cf.gif)

Notice that the channel labels, which are anchored to the offsets, move around during zooming. After zooming out again the channel spacing is not the same as it was before, and the bottom gray trace has completely migrated off the screen!

It's because of this behavior that I have strictly avoided ever using the ygain zoom if I could help it!

This commit changes the behavior of ygain zoom in `by_channel` and `same_for_all` scale modes by making it leave the offsets unchanged. Consequently, signals are scaled around 0 (baseline) instead of their medians, and the zoom is perfectly reversible:

![ygain_zoom_without_offsets](https://user-images.githubusercontent.com/241234/58771464-474d4600-8582-11e9-887d-b14cdf03493f.gif)

Notice here the labels don't move, and everything returns to its original place in the end.

A possibly undesired consequence of this change is that signals with a large, meaningless non-zero baseline, such as a channel with a spurious DC offset, will not expand and contract around its median anymore, but instead will move around the screen. @samuelgarcia, how much are you worried about this? I could instead instantiate a new scale mode that has the behavior I desire, but that seems like a lot more work. 🤣 