### PR TITLE
Use same color determination for EpochEncoder rectangles as EpochViewer

### DIFF
--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -397,12 +397,14 @@ class EpochEncoder(ViewerBase):
         for i, label in enumerate(labels):
             ind = self.source.possible_labels.index(label)
             color = self.by_label_params['label'+str(ind), 'color']
+            color2 = QT.QColor(color)
+            color2.setAlpha(130)
             ypos = n - ind - 1
             if self.params['view_mode']=='stacked':
                 ypos = n - ind - 1
             else:
                 ypos = 0
-            item = RectItem([times[i],  ypos,durations[i], .9],  border='#FFFFFF', fill=color, id=ids[i])
+            item = RectItem([times[i],  ypos,durations[i], .9],  border=color, fill=color2, id=ids[i])
             item.clicked.connect(self.on_rect_clicked)
             item.doubleclicked.connect(self.on_rect_doubleclicked)
             item.setPos(times[i],  ypos)


### PR DESCRIPTION
In EpochViewer, opaque colors are assigned to rectangle borders, and a transparent version of the color is assigned to the rectangle fill. In EpochEncoder, the border was always white, and the interior was the opaque color. This commit changes EpochEncoder to determine colors the same way as EpochViewer.

This is motivated by the new "light mode"/"light theme" I'm building for myself, which has a light colored background in each panel. The old coloring of EpochEncoder had all white borders, which was difficult to see against a light background. And since the border becomes the only thing you can see if the rectangles are small relative to xsize, I had EpochEncoder rectangles basically disappearing against the light background. This change makes EpochEncoder and EpochViewer consistent with one another and solves these problems.

The old white borders might have been chosen intentionally because they looked good against the default black background, and worked especially well when the EpochEncoder was running in "flat" view mode and borders were touching. I hope this new color determination is an acceptable compromise. One advantage of it is that if you have overlapping epochs in flat view mode (not something I recommend, but it can happen I guess), the new transparent fills allow you to see that more than one epoch is there.

@samuelgarcia, I don't want to violate your design aesthetic too much, especially when I think you might have chosen white borders deliberately. Is this change OK with you?