### PR TITLE
Fix error when dragging mouse on viewer axes

### DIFF
--- a/ephyviewer/base.py
+++ b/ephyviewer/base.py
@@ -64,7 +64,7 @@ class MyViewBox(pg.ViewBox):
             z = 1.1 if ev.delta()>0 else 1/1.1
         self.ygain_zoom.emit(z)
         ev.accept()
-    def mouseDragEvent(self, ev):
+    def mouseDragEvent(self, ev, axis=None):
         if ev.button()== QT.RightButton:
             self.xsize_zoom.emit((ev.pos()-ev.lastPos()).x())
         else:


### PR DESCRIPTION
The `mouseDragEvent` triggered when the mouse was dragged in any of the viewers' axes included an unhandled keyword `axis`. This raised a non-fatal TypeError. This commit handles the keyword by ignoring it, which eliminates this error.