### PR TITLE
Fix error when scrolling mouse on viewer axes

### DIFF
--- a/ephyviewer/base.py
+++ b/ephyviewer/base.py
@@ -57,7 +57,7 @@ class MyViewBox(pg.ViewBox):
             self.doubleclicked.emit()
         else:
             ev.ignore()
-    def wheelEvent(self, ev):
+    def wheelEvent(self, ev, axis=None):
         if ev.modifiers() == QT.Qt.ControlModifier:
             z = 5. if ev.delta()>0 else 1/5.
         else:


### PR DESCRIPTION
The `wheelEvent` triggered when the mouse was scrolled in any of the viewers' axes included an unhandled keyword `axis`. This raised a fatal TypeError. This commit handles the keyword by ignoring it, which eliminates this error.

This bug and its solution are both very similar to #51.