### PR TITLE
Fix clicking on current selection in EventList and EpochEncoder table

### DIFF
--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -266,7 +266,7 @@ class EpochEncoder(ViewerBase):
 
         self.table_widget = QT.QTableWidget()
         h.addWidget(self.table_widget)
-        self.table_widget.itemSelectionChanged.connect(self.on_seek_table)
+        self.table_widget.itemClicked.connect(self.on_seek_table)
         self.table_widget.setSelectionMode(QT.QAbstractItemView.SingleSelection)
         self.table_widget.setSelectionBehavior(QT.QAbstractItemView.SelectRows)
 

--- a/ephyviewer/eventlist.py
+++ b/ephyviewer/eventlist.py
@@ -30,7 +30,7 @@ class EventList(ViewerBase):
 
         self.combo.addItems([self.source.get_channel_name(i) for i in range(self.source.nb_channel) ])
 
-        self.list_widget.currentRowChanged.connect(self.select_event)
+        self.list_widget.itemClicked.connect(self.select_event)
 
     @classmethod
     def from_numpy(cls, all_events, name):
@@ -69,7 +69,8 @@ class EventList(ViewerBase):
                 self.list_widget.addItem('{} : {:.3f} {}'.format(i, times[i], labels[i]) )
 
 
-    def select_event(self, i):
+    def select_event(self):
+        i = self.list_widget.currentRow()
 
         #~ ev = self.source.all_events[self.ind]
         #~ t = ev['time'][i]


### PR DESCRIPTION
Selecting items in the EventList or EpochEncoder table would jump time to the start of the event/epoch, unless the clicked item was already selected. In the case of lists/tables containing only one item, there was no way to unselect an item, so in these cases it was impossible to use this feature again after the first use.

This commit changes the trigger for jumping from changing the selection to simply clicking on an item. This allows the user to easily jump to the currently selected item if they have scrolled away from it.