### PR TITLE
Fix real_scale for raw signals when channel_indexes is a subset

### DIFF
--- a/ephyviewer/datasource/neosource.py
+++ b/ephyviewer/datasource/neosource.py
@@ -150,6 +150,12 @@ class AnalogSignalFromNeoRawIOSource(BaseAnalogSignalSource):
                         channel_indexes=self.channel_indexes)
         return length
 
+    def get_gains(self):
+        return self.neorawio.header['signal_channels']['gain'][self.channel_indexes]
+
+    def get_offsets(self):
+        return self.neorawio.header['signal_channels']['offset'][self.channel_indexes]
+
     def get_shape(self):
         return (self.get_length(), self.nb_channel)
 

--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -146,8 +146,8 @@ class TraceViewer_ParamController(Base_MultiChannel_ParamController):
 
             if scale_mode=='real_scale':
                 if isinstance(self.viewer.source, AnalogSignalFromNeoRawIOSource):
-                    gains = self.viewer.source.neorawio.header['signal_channels']['gain']
-                    offsets = self.viewer.source.neorawio.header['signal_channels']['offset']
+                    gains = self.viewer.source.get_gains()
+                    offsets = self.viewer.source.get_offsets()
                 self.viewer.params['ylim_min'] = np.nanmin(self.signals_min[self.visible_channels] * gains[self.visible_channels] + offsets[self.visible_channels])
                 self.viewer.params['ylim_max'] = np.nanmax(self.signals_max[self.visible_channels] * gains[self.visible_channels] + offsets[self.visible_channels])
             else:


### PR DESCRIPTION
If `AnalogSignalFromNeoRawIOSource.channel_indexes` was a subset of channels, instead of all channels, the wrong gains and offsets were fetched and a crash would occur.