### PR TITLE
Catch make_video_file crash

### DIFF
--- a/ephyviewer/tests/testing_tools.py
+++ b/ephyviewer/tests/testing_tools.py
@@ -90,10 +90,13 @@ def make_video_file(filename, codec='mpeg4', rate=25.): # mpeg4 mjpeg libx264
             output.mux(packet)
 
     while True :
-        packet = stream.encode(None)
-        if packet is None:
+        try:
+            packet = stream.encode(None)
+            if packet is None:
+                break
+            output.mux(packet)
+        except av.AVError:
             break
-        output.mux(packet)
 
     output.close()
 


### PR DESCRIPTION
Before this fix, I would get this:

```
(py3) C:\Users\Jeffrey\Documents\python-dev>python ephyviewer\git-repo\ephyviewer\examples\mixed_viewer.py
make_video_file video0.avi
Using AVStream.codec to pass codec parameters to muxers is deprecated, use AVStream.codecpar instead.
Traceback (most recent call last):
  File "ephyviewer\git-repo\ephyviewer\examples\mixed_viewer.py", line 12, in <module>
    video_source = make_fake_video_source()
  File "c:\users\jeffrey\documents\python-dev\ephyviewer\git-repo\ephyviewer\ephyviewer\tests\testing_tools.py", line 109, in make_fake_video_source
    make_video_file(filename, )
  File "c:\users\jeffrey\documents\python-dev\ephyviewer\git-repo\ephyviewer\ephyviewer\tests\testing_tools.py", line 94, in make_video_file
    packet = stream.encode(None)
  File "av/stream.pyx", line 133, in av.stream.Stream.encode
  File "av/codec/context.pyx", line 324, in av.codec.context.CodecContext.encode
  File "av/codec/context.pyx", line 239, in av.codec.context.CodecContext._send_frame_and_recv
  File "av\utils.pyx", line 107, in av.utils.err_check
av.AVError: [Errno 541478725] End of file
```