### PR TITLE
Add a parameter to NavigationToolBar for setting datetime string format

### DIFF
--- a/ephyviewer/navigation.py
+++ b/ephyviewer/navigation.py
@@ -25,6 +25,7 @@ class NavigationToolBar(QT.QWidget) :
     def __init__(self, parent=None, show_play=True, show_step=True,
                                     show_scroll_time=True, show_spinbox=True,
                                     show_label_datetime=False, datetime0=None,
+                                    datetime_format='%Y-%m-%d %H:%M:%S',
                                     show_global_xsize=True, show_auto_scale=True,
                                     play_interval = 0.1) :
 
@@ -50,6 +51,7 @@ class NavigationToolBar(QT.QWidget) :
         self.play_interval = play_interval
 
         self.datetime0 = datetime0
+        self.datetime_format = datetime_format
 
 
         if show_scroll_time:
@@ -272,7 +274,7 @@ class NavigationToolBar(QT.QWidget) :
 
         if self.show_label_datetime:
             dt = self.datetime0 + datetime.timedelta(seconds=self.t)
-            self.label_datetime.setText('{}'.format(dt))
+            self.label_datetime.setText(dt.strftime(self.datetime_format))
 
 
         if emit:


### PR DESCRIPTION
Prior to this commit, the string format defaulted to ``datetime.isoformat(sep=' ', timespec='auto')``, which displayed with microseconds as ``YYYY-MM-DD HH:MM:SS.ffffff`` or, if microsecond was 0, ``YYYY-MM-DD HH:MM:SS``. This resulted in the datetime label changing width depending on the time.

The new default format string drops microseconds entirely. I assume that level of precision for real-world time is neither necessary nor accurate in the majority of cases. Users can get microseconds back by changing the new parameter.