### PR TITLE
Use scientific notation in TraceViewer gain spin boxes less often

### DIFF
--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -42,7 +42,7 @@ default_params = [
 
 default_by_channel_params = [
     {'name': 'color', 'type': 'color', 'value': "55FF00"},
-    {'name': 'gain', 'type': 'float', 'value': 1, 'step': 0.1},
+    {'name': 'gain', 'type': 'float', 'value': 1, 'step': 0.1, 'decimals': 8},
     {'name': 'offset', 'type': 'float', 'value': 0., 'step': 0.1},
     {'name': 'visible', 'type': 'bool', 'value': True},
     ]


### PR DESCRIPTION
Although the [pyqtgraph docs say](http://www.pyqtgraph.org/documentation/widgets/spinbox.html#pyqtgraph.SpinBox.setOpts) that the ``decimals`` option for SpinBox defaults to 6, the behavior differs if that value is provided vs not provided.

Without any value specified, I find that the SpinBoxes for the gains in the TraceViewer switch to scientific notation with values as small as 1000. This is represented as "1e+03". This makes modifying the value much more difficult, because the SpinBox does not actually permit you to enter scientific notation. For example, if you wanted to double the gain, you can't just change "1e+03" to "2e+03". That will be interpreted as 2 instead of 2000 because the "e" and everything after it is dropped.

With ``decimals`` set to 6, I can go all the way up to 1000000 before it starts using scientific notation, as expected.

I decided that still wasn't enough for me, so I bumped ``decimals`` to 8 in this PR.