### PR TITLE
Add TraceViewer label mouse events for adjusting gains and offsets

### DIFF
--- a/doc/interface.rst
+++ b/doc/interface.rst
@@ -19,13 +19,17 @@ Time is easy and intuitive to navigate:
 * Jump to a time by clicking on an event in the event list or a table entry in
   the epoch encoder.
 
-It is also easy to quickly adjust scale:
+It is also easy to quickly adjust scale and placement:
 
 * To show more or less time at once, right-click and drag right or left to
   contract or expand time.
+* Press the auto scale button to automatically scale signals and color maps.
 * Scroll the mouse wheel to zoom in a trace viewer or a video viewer, or to
   rescale the color map in a time-frequency viewer.
-* Press the auto scale button to automatically scale signals and color maps.
+* Scroll the mouse wheel on a trace label to adjust the scale of an individual
+  trace (``by_channel`` scale mode only).
+* Left-click and drag on a trace label to adjust its vertical offset, or in a
+  video viewer to reposition the video frame.
 * Adjust scale mode (real vs arbitrary units) and individual signal gains and
   offsets in the detailed options window of the trace viewer (double click to
   open).

--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -354,6 +354,11 @@ class DataGrabber(QT.QObject):
 
 
 
+class TraceLabelItem(pg.TextItem):
+
+    def __init__(self, **kwargs):
+        pg.TextItem.__init__(self, **kwargs)
+
 
 class TraceViewer(BaseMultiChannelViewer):
     _default_params = default_params
@@ -436,7 +441,7 @@ class TraceViewer(BaseMultiChannelViewer):
             self.curves.append(curve)
 
             ch_name = '{}: {}'.format(c, self.source.get_channel_name(chan=c))
-            label = pg.TextItem(ch_name, color=color, anchor=(0, 0.5), border=None, fill=self.params['label_fill_color'])
+            label = TraceLabelItem(text=ch_name, color=color, anchor=(0, 0.5), border=None, fill=self.params['label_fill_color'])
             label.setZValue(2) # ensure labels are drawn above scatter
 
             self.plot.addItem(label)


### PR DESCRIPTION
This PR adds two mouse interactions for the TraceViewer:

* Left-click and drag on a trace label to change its offset, allowing the user to move a trace up or down easily.
* In ``by_channel`` scale mode only, scroll the mouse wheel on a trace label to rescale just that trace, rather than all traces at once. This feature is disabled in ``real_scale`` and ``same_for_all`` scale modes.

The second feature may be a little difficult to use for labels that move a lot when the gain is changed. This is most likely to occur for signals that aren't centered on zero, like intracellular voltages.