### PR TITLE
Add EpochEncoder shortcut for saving

### DIFF
--- a/doc/interface.rst
+++ b/doc/interface.rst
@@ -58,3 +58,5 @@ The epoch encoder has many modes of interaction as well:
 * Merge overlapping and adjacent epochs of the same type with the "Merge
   neighbors" button.
 * Fill gaps between epochs using the "Fill blank" button.
+* Click "Save" (shortcut: ``Ctrl+s``, or ``Cmd+s`` on Mac) to write the epochs
+  to a file.

--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -202,6 +202,11 @@ class EpochEncoder(ViewerBase):
         g.addWidget(but, 5, 0)
         but.clicked.connect(self.on_save)
 
+        save_shortcut = QT.QShortcut(self)
+        save_shortcut.setKey('Ctrl+s')  # automatically converted to Cmd+s on Mac
+        save_shortcut.activated.connect(but.click)
+        but.setToolTip('Shortcut: Ctrl/Cmd+s')
+
 
         #~ v.addStretch()
         #~ v.addWidget(QT.QFrame(frameShape=QT.QFrame.HLine, frameShadow=QT.QFrame.Sunken))


### PR DESCRIPTION
``Ctrl+s``, or ``Cmd+s`` on Mac