### PR TITLE
Fix error when frame_index is None

### DIFF
--- a/ephyviewer/datasource/video.py
+++ b/ephyviewer/datasource/video.py
@@ -111,7 +111,7 @@ class FrameGrabber:
             frame = None
             for i, (frame_index, next_frame) in enumerate(self.next_frame()):
                 #~ print("   ", i, "NEXT at frame", next_frame, "at ts:", next_frame.pts,next_frame.dts)
-                if frame_index >= target_frame:
+                if frame_index is None or frame_index >= target_frame:
                     frame = next_frame
                     break
 


### PR DESCRIPTION
Some video files (I do not understand all the relevant conditions) may crash when seeking near the last frame:

```
Traceback (most recent call last):
  File "c:\users\jeffrey\documents\python-dev\ephyviewer\git-repo\ephyviewer\ephyviewer\videoviewer.py", line 99, in on_request_frame
    frame = self.fg.get_frame(target_frame)
  File "c:\users\jeffrey\documents\python-dev\ephyviewer\git-repo\ephyviewer\ephyviewer\datasource\video.py", line 114, in get_frame
    if frame_index >= target_frame:
TypeError: '>=' not supported between instances of 'NoneType' and 'int'
```

This change is intended to fix that issue.

However, I don't feel great about this one because I understand neither the root cause of the crash nor why my fix is _not_ a terrible idea. I expected ``frame_index is None`` to be a bad state that shouldn't be ignored, but it seems benign enough with this patch, and everything else I tried didn't work like I expected. For instance, alternatives I thought were reasonable kept giving me this: ``av.AVError: [Errno 541478725] End of file``

My lack of understanding makes me worry I could be introducing bugs, but I tested this change on several video files from different sources and all seems OK. One of these days I'm going to have to spend some time reviewing ``video.py`` carefully to wrap my head around it and PyAV.