### PR TITLE
Fix EpochViewer colors when some channels are not visible

### DIFF
--- a/ephyviewer/epochviewer.py
+++ b/ephyviewer/epochviewer.py
@@ -151,7 +151,7 @@ class EpochViewer(BaseMultiChannelViewer):
             else:
                 raise ValueError("data has unexpected dimensions")
 
-            color = self.by_channel_params.children()[e].param('color').value()
+            color = self.by_channel_params.children()[chan].param('color').value()
             color2 = QT.QColor(color)
             color2.setAlpha(130)
 


### PR DESCRIPTION
The wrong indexing variable was used, causing the wrong colors to be applied to channels listed after any hidden channels.