### PR TITLE
Fix plot range for SpikeTrainViewer when only one channel is visible

### DIFF
--- a/ephyviewer/spiketrainviewer.py
+++ b/ephyviewer/spiketrainviewer.py
@@ -27,7 +27,7 @@ Symbols['|'].closeSubpath()
 
 default_params = [
     {'name': 'xsize', 'type': 'float', 'value': 3., 'step': 0.1},
-    {'name': 'scatter_size', 'type': 'float', 'value': 10.,  'limits': (0,np.inf)},
+    {'name': 'scatter_size', 'type': 'float', 'value': 0.8,  'limits': (0,np.inf)},
     {'name': 'background_color', 'type': 'color', 'value': 'k'},
     {'name': 'vline_color', 'type': 'color', 'value': '#FFFFFFAA'},
     {'name': 'label_fill_color', 'type': 'color', 'value': '#222222DD'},
@@ -119,7 +119,7 @@ class SpikeTrainViewer(BaseMultiChannelViewer):
         self.vline.setZValue(1) # ensure vline is above plot elements
         self.plot.addItem(self.vline)
 
-        self.scatter = pg.ScatterPlotItem(size=self.params['scatter_size'], pxMode = True, symbol='|')
+        self.scatter = pg.ScatterPlotItem(size=self.params['scatter_size'], pxMode = False, symbol='|')
         self.plot.addItem(self.scatter)
 
 
@@ -181,7 +181,7 @@ class SpikeTrainViewer(BaseMultiChannelViewer):
         self.vline.setPos(self.t)
 
         self.plot.setXRange( t_start, t_stop, padding = 0.0)
-        self.plot.setYRange( 0, visibles.size-1)
+        self.plot.setYRange(-self.params['scatter_size']/2, self.params['scatter_size']/2 + visibles.size - 1)
 
     def on_param_change(self, params=None, changes=None):
         for param, change, data in changes:


### PR DESCRIPTION
Fixes a plot range bug for SpikeTrainViewer introduced in 6ac5279 (since v1.2.1). Fixes #94.

Spike times are now plotted with ``pxMode=False``, so their size, specified by ``scatter_size``, is now given in the plot coordinate system, rather than pixels. This allows automatic plot range padding to be computed more intelligently. Resizing a SpikeTrainViewer panel will no longer cause the relative gaps between rows in the raster plot to change. Adjusting ``scatter_size`` will adjust the gap between rows.