### PR TITLE
Add xratio parameter to viewers for controlling vline position

### DIFF
--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -19,6 +19,7 @@ from .datasource import WritableEpochSource
 
 default_params = [
     {'name': 'xsize', 'type': 'float', 'value': 3., 'step': 0.1},
+    {'name': 'xratio', 'type': 'float', 'value': 0.3, 'step': 0.1, 'limits': (0,1)},
     {'name': 'background_color', 'type': 'color', 'value': 'k'},
     {'name': 'vline_color', 'type': 'color', 'value': '#FFFFFFAA'},
     {'name': 'label_fill_color', 'type': 'color', 'value': '#222222DD'},
@@ -69,8 +70,6 @@ class EpochEncoder(ViewerBase):
         self.make_param_controller()
 
         self.viewBox.doubleclicked.connect(self.show_params_controller)
-
-        self._xratio = 0.3
 
         self.initialize_plot()
 
@@ -401,7 +400,8 @@ class EpochEncoder(ViewerBase):
 
     def refresh(self):
         xsize = self.params['xsize']
-        t_start, t_stop = self.t-xsize*self._xratio , self.t+xsize*(1-self._xratio)
+        xratio = self.params['xratio']
+        t_start, t_stop = self.t-xsize*xratio , self.t+xsize*(1-xratio)
         self.request_data.emit(t_start, t_stop, [0])
 
     def on_data_ready(self, t_start, t_stop, visibles, data):

--- a/ephyviewer/epochviewer.py
+++ b/ephyviewer/epochviewer.py
@@ -16,6 +16,7 @@ from .datasource import InMemoryEpochSource, NeoEpochSource
 
 default_params = [
     {'name': 'xsize', 'type': 'float', 'value': 3., 'step': 0.1},
+    {'name': 'xratio', 'type': 'float', 'value': 0.3, 'step': 0.1, 'limits': (0,1)},
     {'name': 'background_color', 'type': 'color', 'value': 'k'},
     {'name': 'vline_color', 'type': 'color', 'value': '#FFFFFFAA'},
     {'name': 'label_fill_color', 'type': 'color', 'value': '#222222DD'},
@@ -98,8 +99,6 @@ class EpochViewer(BaseMultiChannelViewer):
         self.viewBox.doubleclicked.connect(self.show_params_controller)
         self.initialize_plot()
 
-        self._xratio = 0.3
-
         self.thread = QT.QThread(parent=self)
         self.datagrabber = DataGrabber(source=self.source)
         self.datagrabber.moveToThread(self.thread)
@@ -134,7 +133,8 @@ class EpochViewer(BaseMultiChannelViewer):
 
     def refresh(self):
         xsize = self.params['xsize']
-        t_start, t_stop = self.t-xsize*self._xratio , self.t+xsize*(1-self._xratio)
+        xratio = self.params['xratio']
+        t_start, t_stop = self.t-xsize*xratio , self.t+xsize*(1-xratio)
         visibles, = np.nonzero(self.params_controller.visible_channels)
         self.request_data.emit(t_start, t_stop, visibles)
 

--- a/ephyviewer/spiketrainviewer.py
+++ b/ephyviewer/spiketrainviewer.py
@@ -27,6 +27,7 @@ Symbols['|'].closeSubpath()
 
 default_params = [
     {'name': 'xsize', 'type': 'float', 'value': 3., 'step': 0.1},
+    {'name': 'xratio', 'type': 'float', 'value': 0.3, 'step': 0.1, 'limits': (0,1)},
     {'name': 'scatter_size', 'type': 'float', 'value': 0.8,  'limits': (0,np.inf)},
     {'name': 'background_color', 'type': 'color', 'value': 'k'},
     {'name': 'vline_color', 'type': 'color', 'value': '#FFFFFFAA'},
@@ -78,8 +79,6 @@ class SpikeTrainViewer(BaseMultiChannelViewer):
         self.make_param_controller()
 
         self.viewBox.doubleclicked.connect(self.show_params_controller)
-
-        self._xratio = 0.3
 
         self.initialize_plot()
 
@@ -136,7 +135,8 @@ class SpikeTrainViewer(BaseMultiChannelViewer):
 
     def refresh(self):
         xsize = self.params['xsize']
-        t_start, t_stop = self.t-xsize*self._xratio , self.t+xsize*(1-self._xratio)
+        xratio = self.params['xratio']
+        t_start, t_stop = self.t-xsize*xratio , self.t+xsize*(1-xratio)
         visibles, = np.nonzero(self.params_controller.visible_channels)
         self.request_data.emit(t_start, t_stop, visibles)
 

--- a/ephyviewer/timefreqviewer.py
+++ b/ephyviewer/timefreqviewer.py
@@ -25,6 +25,7 @@ import threading
 
 default_params = [
     {'name': 'xsize', 'type': 'float', 'value': 3., 'step': 0.1},
+    {'name': 'xratio', 'type': 'float', 'value': 0.3, 'step': 0.1, 'limits': (0,1)},
     {'name': 'nb_column', 'type': 'int', 'value': 4},
     {'name': 'background_color', 'type': 'color', 'value': 'k'},
     {'name': 'vline_color', 'type': 'color', 'value': '#FFFFFFAA'},
@@ -262,7 +263,6 @@ class TimeFreqViewer(BaseMultiChannelViewer):
         self.initialize_time_freq()
 
 
-        self._xratio = 0.3
         self.last_wt_maps = {}
 
         self.threads = []
@@ -395,7 +395,8 @@ class TimeFreqViewer(BaseMultiChannelViewer):
         visible_channels = self.params_controller.visible_channels
 
         xsize = self.params['xsize']
-        t_start, t_stop = self.t-xsize*self._xratio , self.t+xsize*(1-self._xratio)
+        xratio = self.params['xratio']
+        t_start, t_stop = self.t-xsize*xratio , self.t+xsize*(1-xratio)
 
         for c in range(self.source.nb_channel):
             if visible_channels[c]:

--- a/ephyviewer/traceviewer.py
+++ b/ephyviewer/traceviewer.py
@@ -25,6 +25,7 @@ import threading
 
 default_params = [
     {'name': 'xsize', 'type': 'float', 'value': 3., 'step': 0.1},
+    {'name': 'xratio', 'type': 'float', 'value': 0.3, 'step': 0.1, 'limits': (0,1)},
     {'name': 'ylim_max', 'type': 'float', 'value': 10.},
     {'name': 'ylim_min', 'type': 'float', 'value': -10.},
     {'name': 'scatter_size', 'type': 'float', 'value': 10.,  'limits': (0,np.inf)},
@@ -430,8 +431,6 @@ class TraceViewer(BaseMultiChannelViewer):
 
         self.initialize_plot()
 
-        self._xratio = 0.3
-
         self.last_sigs_chunk = None
 
         self.thread = QT.QThread(parent=self)
@@ -534,7 +533,8 @@ class TraceViewer(BaseMultiChannelViewer):
         #~ print('auto_scale', self.last_sigs_chunk)
         if self.last_sigs_chunk is None:
             xsize = self.params['xsize']
-            t_start, t_stop = self.t-xsize*self._xratio , self.t+xsize*(1-self._xratio)
+            xratio = self.params['xratio']
+            t_start, t_stop = self.t-xsize*xratio , self.t+xsize*(1-xratio)
             visibles, = np.nonzero(self.params_controller.visible_channels)
             total_gains = self.params_controller.total_gains
             total_offsets = self.params_controller.total_offsets
@@ -548,7 +548,8 @@ class TraceViewer(BaseMultiChannelViewer):
     def refresh(self):
         #~ print('TraceViewer.refresh', 't', self.t)
         xsize = self.params['xsize']
-        t_start, t_stop = self.t-xsize*self._xratio , self.t+xsize*(1-self._xratio)
+        xratio = self.params['xratio']
+        t_start, t_stop = self.t-xsize*xratio , self.t+xsize*(1-xratio)
         visibles, = np.nonzero(self.params_controller.visible_channels)
         total_gains = self.params_controller.total_gains
         total_offsets = self.params_controller.total_offsets


### PR DESCRIPTION
The parameter may vary between 0 and 1 and controls the fraction of the displayed data that is in the "past", preceding the current time. Default: 0.3.

With xratio set to 1, all displayed data precedes the current t, so only "past" data is shown. With xratio set to 0, all displayed data follows the current t, so only "future" data is shown.