### PR TITLE
Fix bounds of EpochEncoder time range selector's spin boxes

### DIFF
--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -586,6 +586,11 @@ class EpochEncoder(ViewerBase):
         self.has_unsaved_changes = False
 
     def on_spin_limit_changed(self, v):
+        # ensure lower bound <= upper bound
+        self.spin_limit1.setMaximum(self.spin_limit2.value())
+        self.spin_limit2.setMinimum(self.spin_limit1.value())
+
+        # update region
         self.region.blockSignals(True)
         rgn = (self.spin_limit1.value(), self.spin_limit2.value())
         rgn = self.region.setRegion(rgn)


### PR DESCRIPTION
This change prevents the range's lower bound from being set to a value greater than its upper bound using the spin boxes, and vice versa.