### PR TITLE
Reorganize EpochEncoder controls to reduce crowding

### DIFF
--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -270,7 +270,7 @@ class EpochEncoder(ViewerBase):
         self.range_group_box.clicked.connect(self.on_range_visibility_changed)
         h.addWidget(self.range_group_box)
 
-        range_group_box_layout = QT.QVBoxLayout()
+        range_group_box_layout = QT.QGridLayout()
         self.range_group_box.setLayout(range_group_box_layout)
 
         range_shortcut = QT.QShortcut(self)
@@ -281,13 +281,11 @@ class EpochEncoder(ViewerBase):
         spinboxs = []
         buts = []
         for i, but_text in enumerate(['Set start >', 'Set stop >']):
-            hh = QT.QHBoxLayout()
-            range_group_box_layout.addLayout(hh)
             but = QT.QPushButton(but_text)
             buts.append(but)
-            hh.addWidget(but)
+            range_group_box_layout.addWidget(but, i, 0)
             spinbox = pg.SpinBox(value=float(i), decimals = 8, bounds = (-np.inf, np.inf),step = 0.05, siPrefix=False, int=False)
-            hh.addWidget(spinbox, 10)
+            range_group_box_layout.addWidget(spinbox, i, 1)
             spinbox.setSizePolicy(QT.QSizePolicy.Preferred, QT.QSizePolicy.Preferred, )
             spinbox.valueChanged.connect(self.on_spin_limit_changed)
             spinboxs.append(spinbox)
@@ -307,15 +305,15 @@ class EpochEncoder(ViewerBase):
 
         self.combo_labels = QT.QComboBox()
         self.combo_labels.addItems(self.source.possible_labels)
-        range_group_box_layout.addWidget(self.combo_labels)
+        range_group_box_layout.addWidget(self.combo_labels, 2, 0, 1, 2)
 
         self.but_apply_region = QT.PushButton('Insert within range')
-        range_group_box_layout.addWidget(self.but_apply_region)
+        range_group_box_layout.addWidget(self.but_apply_region, 3, 0, 1, 2)
         self.but_apply_region.clicked.connect(self.apply_region)
         self.but_apply_region.setToolTip('Insert with customizable shortcuts (see options)')
 
         self.but_del_region = QT.PushButton('Clear within range')
-        range_group_box_layout.addWidget(self.but_del_region)
+        range_group_box_layout.addWidget(self.but_del_region, 4, 0, 1, 2)
         self.but_del_region.clicked.connect(self.delete_region)
 
         self.table_widget = QT.QTableWidget()

--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -146,6 +146,8 @@ class EpochEncoder(ViewerBase):
         self.datagrabber.data_ready.connect(self.on_data_ready)
         self.request_data.connect(self.datagrabber.on_request_data)
 
+        self.table_button_fixed_width = 32
+        self.table_button_icon_size = 16
         self.refresh_table()
 
         # IMPORTANT: Any time the contents of self.source are changed (e.g., by
@@ -657,16 +659,25 @@ class EpochEncoder(ViewerBase):
         self.table_widget.setRowCount(times.size)
         self.table_widget.setHorizontalHeaderLabels(['', 'start', 'stop', 'duration', 'label', '', '', ''])
 
-        # lock column widths for button and label columns to fit contents
-        for col in [SEEK_COL, LABEL_COL, SPLIT_COL, DUPLICATE_COL, DELETE_COL]:
-            self.table_widget.horizontalHeader().setSectionResizeMode(col, QT.QHeaderView.ResizeToContents)
+        # lock column widths for buttons to fixed button width
+        self.table_widget.horizontalHeader().setMinimumSectionSize(self.table_button_fixed_width)
+        for col in [SEEK_COL, SPLIT_COL, DUPLICATE_COL, DELETE_COL]:
+            self.table_widget.horizontalHeader().setSectionResizeMode(col, QT.QHeaderView.Fixed)
+            self.table_widget.setColumnWidth(col, self.table_button_fixed_width)
+
+        # lock column width for labels to fit contents
+        self.table_widget.horizontalHeader().setSectionResizeMode(LABEL_COL, QT.QHeaderView.ResizeToContents)
+
+        buttonFlat = True
 
         for r in range(times.size):
 
             # seek button
             but = QT.QPushButton(icon=QT.QIcon(':/epoch-encoder-seek.svg'))
             but.setToolTip('Jump to epoch')
-            but.setFlat(True)
+            but.setFlat(buttonFlat)
+            but.setFixedWidth(self.table_button_fixed_width)
+            but.setIconSize(QT.QSize(self.table_button_icon_size, self.table_button_icon_size))
             but.clicked.connect(lambda checked, r=r: self.on_seek_table(r))
             self.table_widget.setCellWidget(r, SEEK_COL, but)
 
@@ -697,21 +708,27 @@ class EpochEncoder(ViewerBase):
             # split button
             but = QT.QPushButton(icon=QT.QIcon(':/epoch-encoder-split.svg'))
             but.setToolTip('Split epoch at current time')
-            but.setFlat(True)
+            but.setFlat(buttonFlat)
+            but.setFixedWidth(self.table_button_fixed_width)
+            but.setIconSize(QT.QSize(self.table_button_icon_size, self.table_button_icon_size))
             but.clicked.connect(lambda checked, r=r: self.split_selected_epoch(r))
             self.table_widget.setCellWidget(r, SPLIT_COL, but)
 
             # duplicate button
             but = QT.QPushButton(icon=QT.QIcon(':/epoch-encoder-duplicate.svg'))
             but.setToolTip('Duplicate epoch')
-            but.setFlat(True)
+            but.setFlat(buttonFlat)
+            but.setFixedWidth(self.table_button_fixed_width)
+            but.setIconSize(QT.QSize(self.table_button_icon_size, self.table_button_icon_size))
             but.clicked.connect(lambda checked, r=r: self.duplicate_selected_epoch(r))
             self.table_widget.setCellWidget(r, DUPLICATE_COL, but)
 
             # delete button
             but = QT.QPushButton(icon=QT.QIcon(':/epoch-encoder-delete.svg'))
             but.setToolTip('Delete epoch')
-            but.setFlat(True)
+            but.setFlat(buttonFlat)
+            but.setFixedWidth(self.table_button_fixed_width)
+            but.setIconSize(QT.QSize(self.table_button_icon_size, self.table_button_icon_size))
             but.clicked.connect(lambda checked, r=r: self.delete_selected_epoch(r))
             self.table_widget.setCellWidget(r, DELETE_COL, but)
 

--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -205,7 +205,6 @@ class EpochEncoder(ViewerBase):
 
         self.mainlayout.addSpacing(10)
 
-
         self.but_toggle_controls = QT.ToolButton()
         self.but_toggle_controls.setStyleSheet('QToolButton { border: none; }');
         self.but_toggle_controls.setToolButtonStyle(QT.Qt.ToolButtonTextBesideIcon)
@@ -215,12 +214,17 @@ class EpochEncoder(ViewerBase):
         self.but_toggle_controls.clicked.connect(self.on_controls_visibility_changed)
 
         self.controls = QT.QWidget()
+        self.controls.setSizePolicy(QT.QSizePolicy.Preferred, QT.QSizePolicy.Fixed)
         self.mainlayout.addWidget(self.controls)
 
         h = QT.QHBoxLayout()
+        h.setContentsMargins(0, 0, 0, 0)
+        h.setSpacing(5)
         self.controls.setLayout(h)
 
         v = QT.QVBoxLayout()
+        v.setContentsMargins(0, 0, 0, 0)
+        v.setSpacing(0)
         h.addLayout(v)
 
         but = QT.PushButton('Options')
@@ -240,6 +244,8 @@ class EpochEncoder(ViewerBase):
         group_box = QT.QGroupBox('Epoch insertion mode')
         group_box.setToolTip('Hold Shift when using shortcut keys to temporarily switch modes')
         group_box_layout = QT.QVBoxLayout()
+        group_box_layout.setContentsMargins(0, 0, 0, 0)
+        group_box_layout.setSpacing(0)
         group_box.setLayout(group_box_layout)
         v.addWidget(group_box)
 
@@ -271,6 +277,8 @@ class EpochEncoder(ViewerBase):
         h.addWidget(self.range_group_box)
 
         range_group_box_layout = QT.QGridLayout()
+        range_group_box_layout.setContentsMargins(0, 0, 0, 0)
+        range_group_box_layout.setSpacing(0)
         self.range_group_box.setLayout(range_group_box_layout)
 
         range_shortcut = QT.QShortcut(self)

--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -203,14 +203,12 @@ class EpochEncoder(ViewerBase):
         self.plot.hideButtons()
         self.graphicsview.setCentralItem(self.plot)
 
-        self.mainlayout.addSpacing(10)
-
         self.controls = QT.QWidget()
         self.controls.setSizePolicy(QT.QSizePolicy.Preferred, QT.QSizePolicy.Fixed)
         self.mainlayout.addWidget(self.controls)
 
         h = QT.QHBoxLayout()
-        h.setContentsMargins(0, 0, 0, 0)
+        h.setContentsMargins(5, 5, 0, 0)
         h.setSpacing(5)
         self.controls.setLayout(h)
 
@@ -221,7 +219,6 @@ class EpochEncoder(ViewerBase):
         h.addWidget(self.range_group_box)
 
         range_group_box_layout = QT.QGridLayout()
-        range_group_box_layout.setContentsMargins(0, 0, 0, 0)
         range_group_box_layout.setSpacing(0)
         self.range_group_box.setLayout(range_group_box_layout)
 


### PR DESCRIPTION
All buttons and controls originally in the left column ("Options", "Merge neighbors", "Fill blank", "Epoch insertion mode", "Save") have been moved into a toolbar at the bottom of the EpochEncoder, along with the "Hide controls"/"Show controls" button. Additionally, internal margins, as well as button widths in the table, were made smaller.

These changes greatly improve the amount of space available for the table. This was especially needed on macOS, where the default margins and padding for all control elements are excessively big.

Before (notice table does not fit):

> ![image](https://user-images.githubusercontent.com/241234/95040754-92a9c400-06a2-11eb-9fe3-edf2dfc711a3.png)

After (table fits easily, and new toolbar at bottom):

> ![image](https://user-images.githubusercontent.com/241234/95040772-a9501b00-06a2-11eb-9df4-24388d3dd36d.png)

It would be nice to develop icons for each toolbar button in the future, but for now plain text will do.