### PR TITLE
Prevent overzealous spin box height correction in pyqtgraph 0.11.0

### DIFF
--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -234,6 +234,8 @@ class EpochEncoder(ViewerBase):
             buts.append(but)
             range_group_box_layout.addWidget(but, i, 0)
             spinbox = pg.SpinBox(value=float(i), decimals = 8, bounds = (-np.inf, np.inf),step = 0.05, siPrefix=False, int=False)
+            if 'compactHeight' in spinbox.opts:  # pyqtgraph >= 0.11.0
+                spinbox.setOpts(compactHeight=False)
             range_group_box_layout.addWidget(spinbox, i, 1)
             spinbox.setSizePolicy(QT.QSizePolicy.Preferred, QT.QSizePolicy.Preferred, )
             spinbox.valueChanged.connect(self.on_spin_limit_changed)

--- a/ephyviewer/navigation.py
+++ b/ephyviewer/navigation.py
@@ -84,6 +84,8 @@ class NavigationToolBar(QT.QWidget) :
 
             h.addWidget(QT.QLabel('Speed:'))
             self.speedSpin = pg.SpinBox(bounds=(0.01, 100.), step=0.1, value=1.)
+            if 'compactHeight' in self.speedSpin.opts:  # pyqtgraph >= 0.11.0
+                self.speedSpin.setOpts(compactHeight=False)
             h.addWidget(self.speedSpin)
             self.speedSpin.valueChanged.connect(self.on_change_speed)
 
@@ -139,6 +141,8 @@ class NavigationToolBar(QT.QWidget) :
         if show_spinbox:
             h.addWidget(QT.QLabel('Time (s):'))
             self.spinbox_time =pg.SpinBox(decimals = 8, bounds = (-np.inf, np.inf),step = 0.05, siPrefix=False, suffix='', int=False)
+            if 'compactHeight' in self.spinbox_time.opts:  # pyqtgraph >= 0.11.0
+                self.spinbox_time.setOpts(compactHeight=False)
             h.addWidget(self.spinbox_time)
             #trick for separator
             h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
@@ -157,6 +161,8 @@ class NavigationToolBar(QT.QWidget) :
         if show_global_xsize:
             h.addWidget(QT.QLabel('Time width (s):'))
             self.spinbox_xsize =pg.SpinBox(value=3., decimals = 8, bounds = (0.001, np.inf),step = 0.1, siPrefix=False, suffix='', int=False)
+            if 'compactHeight' in self.spinbox_xsize.opts:  # pyqtgraph >= 0.11.0
+                self.spinbox_xsize.setOpts(compactHeight=False)
             h.addWidget(self.spinbox_xsize)
             #~ self.spinbox_xsize.valueChanged.connect(self.on_spinbox_xsize_changed)
             self.spinbox_xsize.valueChanged.connect(self.xsize_changed.emit)


### PR DESCRIPTION
pyqtgraph 0.11.0 introduced the `compactHeight` parameter for spin boxes, which is on by default. This was intended to reduce excessive vertical white space within spin boxes, but I find that it overcompensates and makes them look worse (or at least no better) across platforms (checked Windows 10, macOS, and Ubuntu).

Here are examples from Ubuntu, where the numbers inside the spin boxes were being clipped:

Before:

> ![image](https://user-images.githubusercontent.com/241234/95041812-c803e100-06a5-11eb-89b2-24f2335b5293.png)

After:

> ![image](https://user-images.githubusercontent.com/241234/95041896-04374180-06a6-11eb-9a92-c893127e1666.png)
