### PR TITLE
Fix signal grouping in get_sources_from_neo_rawio() for Neo 0.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ ephyviewer.egg-info/*
 ephyviewer/tests/*.avi
 examples/*.avi
 examples/*.csv
+/.idea
+/venv

--- a/ephyviewer/datasource/neosource.py
+++ b/ephyviewer/datasource/neosource.py
@@ -288,7 +288,7 @@ def get_sources_from_neo_rawio(neorawio):
 
     if neorawio.signal_channels_count()>0:
         #Signals
-        for channel_indexes in neorawio.get_group_channel_indexes():
+        for channel_indexes in neorawio.get_group_signal_channel_indexes():
             #one soure by channel group
             sources['signal'].append(AnalogSignalFromNeoRawIOSource(neorawio, channel_indexes))
 

--- a/ephyviewer/datasource/neosource.py
+++ b/ephyviewer/datasource/neosource.py
@@ -288,7 +288,13 @@ def get_sources_from_neo_rawio(neorawio):
 
     if neorawio.signal_channels_count()>0:
         #Signals
-        for channel_indexes in neorawio.get_group_signal_channel_indexes():
+        try:
+            # Neo >= 0.9.0
+            channel_indexes_list = neorawio.get_group_signal_channel_indexes()
+        except AttributeError:
+            # Neo < 0.9.0
+            channel_indexes_list = neorawio.get_group_channel_indexes()
+        for channel_indexes in channel_indexes_list:
             #one soure by channel group
             sources['signal'].append(AnalogSignalFromNeoRawIOSource(neorawio, channel_indexes))
 


### PR DESCRIPTION
Simple change to use new get_group_signal_channel_indexes in Neo 0.9.0 release.