### PR TITLE
Increase EpochEncoder's undo_history_size default value

### DIFF
--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -30,7 +30,7 @@ default_params = [
     {'name': 'exclusive_mode', 'type': 'bool', 'value': True},
     {'name': 'view_mode', 'type': 'list', 'value':'stacked', 'values' : ['stacked', 'flat']},
     {'name': 'keys_as_ticks', 'type': 'bool', 'value': True},
-    {'name': 'undo_history_size', 'type': 'int', 'value': 20, 'limits': (1, np.inf)},
+    {'name': 'undo_history_size', 'type': 'int', 'value': 500, 'limits': (1, np.inf)},
 
     #~ {'name': 'display_labels', 'type': 'bool', 'value': True},
     ]


### PR DESCRIPTION
A back-of-the-envelope calculation as well as actual tests suggests that, for a very large set of 600 epochs with moderately short labels, the undo history would not grow to 10 MB until it reached a depth of about 500 steps. Seems reasonable to me!