### PR TITLE
Allow standalone app to open multiple files, each in independent windows

### DIFF
--- a/ephyviewer/scripts.py
+++ b/ephyviewer/scripts.py
@@ -4,19 +4,35 @@ import os
 import argparse
 from ephyviewer.datasource import HAVE_NEO
 from ephyviewer.standalone import all_neo_rawio_dict, rawio_gui_params
+from ephyviewer import __version__
 
 def launch_standalone_ephyviewer():
     from ephyviewer.standalone import StandAloneViewer
     import pyqtgraph as pg
-    assert HAVE_NEO, 'Must have neo 0.6.0'
+    assert HAVE_NEO, 'Must have Neo >= 0.6.0'
     import neo
 
 
     argv = sys.argv[1:]
 
-    parser = argparse.ArgumentParser(description='tridesclous')
-    parser.add_argument('file_or_dir', help='', default=None, nargs='?')
-    parser.add_argument('-f', '--format', help='File format', default=None)
+    description = """
+    Visualize electrophysiological data stored in files readable with Neo's
+    RawIO classes
+    """
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('file_or_dir', default=None, nargs='?',
+                        help='an optional path to a data file or directory, '
+                             'which will be opened immediately (the file '
+                             'format will be inferred from the file '
+                             'extension, if possible; otherwise, --format is '
+                             'required)')
+    parser.add_argument('-V', '--version', action='version',
+                        version='ephyviewer {}'.format(__version__))
+    parser.add_argument('-f', '--format', default=None,
+                        help='specify one of the following formats to '
+                             'override the format detected automatically for '
+                             'file_or_dir: {}'.format(
+                             ', '.join(all_neo_rawio_dict.keys())))
 
     app = pg.mkQApp()
     win = StandAloneViewer()
@@ -32,11 +48,11 @@ def launch_standalone_ephyviewer():
         else:
             neo_rawio_class = all_neo_rawio_dict.get(args.format, None)
 
-        assert neo_rawio_class is not None, 'Unknown format. Format list: ['+','.join(all_neo_rawio_dict.keys())+']'
+        assert neo_rawio_class is not None, 'Unknown format. Format list: {}'.format(', '.join(all_neo_rawio_dict.keys()))
 
         name = neo_rawio_class.__name__.replace('RawIO', '')
         if name in rawio_gui_params:
-            raise(Exception('This IO needs arguments. Do ephyviewer and use open menu'))
+            raise(Exception('This IO requires additional parameters. Run ephyviewer without arguments to input these via the GUI.'))
 
         win.load_dataset(neo_rawio_class=neo_rawio_class, file_or_dir_names=[file_or_dir_name])
 

--- a/ephyviewer/scripts.py
+++ b/ephyviewer/scripts.py
@@ -7,7 +7,7 @@ from ephyviewer.standalone import all_neo_rawio_dict, rawio_gui_params
 from ephyviewer import __version__
 
 def launch_standalone_ephyviewer():
-    from ephyviewer.standalone import StandAloneViewer
+    from ephyviewer.standalone import WindowManager
     import pyqtgraph as pg
     assert HAVE_NEO, 'Must have Neo >= 0.6.0'
     import neo
@@ -35,8 +35,8 @@ def launch_standalone_ephyviewer():
                              ', '.join(all_neo_rawio_dict.keys())))
 
     app = pg.mkQApp()
-    win = StandAloneViewer()
-    win.show()
+
+    manager = WindowManager()
 
     if len(argv)>=1:
         args = parser.parse_args(argv)
@@ -54,10 +54,13 @@ def launch_standalone_ephyviewer():
         if name in rawio_gui_params:
             raise(Exception('This IO requires additional parameters. Run ephyviewer without arguments to input these via the GUI.'))
 
-        win.load_dataset(neo_rawio_class=neo_rawio_class, file_or_dir_names=[file_or_dir_name])
+        manager.load_dataset(neo_rawio_class=neo_rawio_class, file_or_dir_names=[file_or_dir_name])
 
+    else:
+        manager.open_dialog()
 
-    app.exec_()
+    if manager.windows:
+        app.exec_()
 
 if __name__=='__main__':
     launch_standalone_ephyviewer()

--- a/ephyviewer/tests/test_standalone.py
+++ b/ephyviewer/tests/test_standalone.py
@@ -1,16 +1,17 @@
 
 
 
-from ephyviewer.standalone import StandAloneViewer, RawNeoOpenDialog
+from ephyviewer.standalone import WindowManager, RawNeoOpenDialog
 import pyqtgraph as pg
 
 
 
-def test_StandAloneViewer():
+def test_WindowManager():
     app = pg.mkQApp()
-    win = StandAloneViewer()
-    win.show()
-    app.exec_()
+    manager = WindowManager()
+    manager.open_dialog()
+    if manager.windows:
+        app.exec_()
 
 
 def test_RawNeoOpenDialog():
@@ -24,5 +25,5 @@ def test_RawNeoOpenDialog():
 
 
 if __name__=='__main__':
-    test_StandAloneViewer()
+    test_WindowManager()
     #~ test_RawNeoOpenDialog()


### PR DESCRIPTION
Closes #122.

`StandAloneViewer` was replaced by `WindowManager`, which handles spawning a new `MainViewer` each time the Open menu action is used. `WindowManager` also cleans up file locks and deallocates memory when a `MainViewer` is closed.

Additionally, when the app is run from the command line without arguments, the `RawNeoOpenDialog` is launched immediately, rather than the user being required to launch it manually with the Open menu action.

Finally, many of the command line interface's help and error messages have been improved.