### PR TITLE
Fix `'method' object is not connected` error for TimeFreqViewer

### DIFF
--- a/ephyviewer/tools.py
+++ b/ephyviewer/tools.py
@@ -74,7 +74,7 @@ def create_plot_grid(graphiclayout, nb_column, visible_channels, ViewBoxClass=pg
         #~ plot.showAxis('left', False)
         #~ plot.showAxis('bottom', False)
 
-        graphiclayout.ci.layout.addItem(plot, r, c)  # , rowspan, colspan)
+        graphiclayout.addItem(plot, r, c)  # , rowspan, colspan)
         if r not in graphiclayout.ci.rows:
             graphiclayout.ci.rows[r] = {}
         graphiclayout.ci.rows[r][c] = plot


### PR DESCRIPTION
Fixes #124.

pyqtgraph 0.11.0 added the connection and disconnection of a signal to `GraphicsLayout.addItem` and `GraphicsLayout.removeItem`, respectively. ephyviewer's `create_plot_grid` was bypassing the initial connection by calling not `GraphicsLayout.addItem`, but `GraphicsLayout.layout.addItem` instead. When `GraphicsLayout.removeItem` was later used, the signal disconnection step raised an error because the signal was never connected in the first place.

This change makes sure the correct `addItem` method is called, so that the signal is initially connected.