### PR TITLE
Force repaint of EpochEncoder's spin boxes after use of "Set start"/"Set stop" buttons

### DIFF
--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -715,10 +715,12 @@ class EpochEncoder(ViewerBase):
     def set_limit1(self):
         if self.t<self.spin_limit2.value():
             self.spin_limit1.setValue(self.t)
+            self.spin_limit1.repaint()  # needed on macOS
 
     def set_limit2(self):
         if self.t>self.spin_limit1.value():
             self.spin_limit2.setValue(self.t)
+            self.spin_limit2.repaint()  # needed on macOS
 
     def refresh_table(self):
         self.table_widget.blockSignals(True)


### PR DESCRIPTION
Fixes #115.

Why this is needed at all, and especially why so on just one platform, is a mystery to me. Possibly caused by a macOS-specific implementation detail in Qt/PyQt...