### PR TITLE
Stretch instead of shift epoch when start time is edited in EpochEncoder table

### DIFF
--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -869,14 +869,19 @@ class EpochEncoder(ViewerBase):
 
             if col == START_COL:
 
+                # get the epoch stop time
+                stop_time = self.source.ep_times[row] + self.source.ep_durations[row]
+
                 # change epoch start time
                 self.source.ep_times[row] = new_number
 
-                # update epoch stop time in table
-                stop_line_edit = self.table_widget.item(row, STOP_COL)
-                new_stop_time = self.source.ep_times[row] + self.source.ep_durations[row]
-                new_stop_time = np.round(new_stop_time, 6) # round to nearest microsecond
-                stop_line_edit.setText(str(new_stop_time))
+                # change epoch duration to keep stop time unchanged
+                self.source.ep_durations[row] = stop_time - self.source.ep_times[row]
+
+                # update epoch duration in table
+                duration_line_edit = self.table_widget.item(row, DURATION_COL)
+                new_duration = np.round(self.source.ep_durations[row], 6) # round to nearest microsecond
+                duration_line_edit.setText(str(new_duration))
 
             elif col == STOP_COL:
 


### PR DESCRIPTION
Adjusting an epoch start time in the EpochEncoder table will now cause its duration to change while maintaining its stop time (i.e., shorten or lengthen the epoch = new behavior), rather than causing its stop time to change while maintaining its duration (i.e., shifting the epoch forward or backward in time = old behavior).

In my experience, this new behavior is usually what users intend when they change the start time.