### PR TITLE
Add minimal GitHub Actions workflow for testing installation, importing the package, and building the docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,11 +5,14 @@ on: [push, pull_request]
 jobs:
   test-linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.4', '3.5', '3.6', '3.7', '3.8', '3.9']
     steps:
-        - name: Set up Python 3.x
+        - name: Set up Python ${{ matrix.python-version }}
           uses: actions/setup-python@v2
           with:
-            python-version: '3.x'
+            python-version: ${{ matrix.python-version }}
 
         - name: Checkout repository
           uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: tests
+
+on: [push, pull_request]
+
+jobs:
+  test-linux:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Set up Python 3.x
+          uses: actions/setup-python@v2
+          with:
+            python-version: '3.x'
+
+        - name: Checkout repository
+          uses: actions/checkout@v2
+
+        - name: Install package from repository
+          run: |
+            pip install -e .
+
+        - name: Install other required dependencies
+          run: |
+            pip install PyQt5
+
+        - name: List pip packages
+          run: |
+            pip -V
+            pip list
+
+        - name: Test imports
+          run: |
+            python -c "import ephyviewer"
+            python -c "import ephyviewer.datasource"
+            python -c "import ephyviewer.icons"
+            python -c "import ephyviewer.tests"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.4', '3.5', '3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9']
     steps:
         - name: Set up Python ${{ matrix.python-version }}
           uses: actions/setup-python@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,31 @@ name: tests
 on: [push, pull_request]
 
 jobs:
+  test-docs:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Set up Python 3.7
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.7
+
+        - name: Checkout repository
+          uses: actions/checkout@v2
+
+        - name: Install package from repository with docs dependencies
+          run: |
+            pip install -e .[docs]
+
+        - name: List pip packages
+          run: |
+            pip -V
+            pip list
+
+        - name: Build docs
+          run: |
+            cd doc
+            make html
+
   test-linux:
     runs-on: ubuntu-latest
     strategy:

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -4,7 +4,7 @@ Installation
 ============
 
 Requirements:
-  * Python ≥ 3.4
+  * Python ≥ 3.5
   * numpy
   * scipy
   * matplotlib ≥ 2.0

--- a/ephyviewer/datasource/epochs.py
+++ b/ephyviewer/datasource/epochs.py
@@ -77,7 +77,7 @@ class WritableEpochSource(InMemoryEpochSource):
         # add labels missing from possible_labels but found in epoch data
         new_labels_from_data = list(set(epoch['label'])-set(self.possible_labels))
         if restrict_to_possible_labels:
-            assert len(new_labels_from_data)==0, f'epoch data contains labels not found in possible_labels: {new_labels_from_data}'
+            assert len(new_labels_from_data)==0, 'epoch data contains labels not found in possible_labels: ' + str(new_labels_from_data)
         self.possible_labels += new_labels_from_data
 
         # put the epochs into a canonical order after loading

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+# these restricted versions are defaults on ReadTheDocs, so use the same in
+# local builds and in tests
+sphinx<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+matplotlib>=2.0
+numpy
+pyqtgraph>=0.10.0
+scipy

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,8 @@ from setuptools import setup, find_packages
 import os
 
 
-install_requires = [
-                    'numpy',
-                    #~ 'PyQt5',
-                    'pyqtgraph>=0.10.0',
-                    'matplotlib>=2.0',
-                    'scipy',
-                    ]
+with open('requirements.txt', 'r') as f:
+    install_requires = f.read()
 
 # Read in the README to serve as the long_description, which will be presented
 # on pypi.org as the project description.

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,6 @@ from setuptools import setup, find_packages
 import os
 
 
-with open('requirements.txt', 'r') as f:
-    install_requires = f.read()
-
 # Read in the README to serve as the long_description, which will be presented
 # on pypi.org as the project description.
 with open('README.rst', 'r') as f:
@@ -15,15 +12,21 @@ with open('ephyviewer/version.py') as f:
     exec(f.read(), None, d)
     version = d['version']
 
+with open('requirements.txt', 'r') as f:
+    install_requires = f.read()
+
+extras_require = {}
+with open('requirements-docs.txt', 'r') as f:
+    extras_require['docs'] = f.read()
 
 entry_points={'console_scripts': ['ephyviewer=ephyviewer.scripts:launch_standalone_ephyviewer']}
-
 
 setup(
     name = 'ephyviewer',
     version = version,
     packages = find_packages(),
     install_requires = install_requires,
+    extras_require = extras_require,
     author = 'S.Garcia, Jeffrey Gill',
     author_email = '',  # left blank because multiple emails cannot be provided
     description = 'Simple viewers for ephys signals, events, video and more',


### PR DESCRIPTION
This pull request adds a minimal GitHub Actions workflow file which
1. Tests that the docs can be build, and
2. Tests that the package can be installed with `pip install .` and that `import ephyviewer` works afterward.

Note that this does not actually run any of the tests in `ephyviewer/tests`! Those tests will require tweaking to run without human interaction (at minimum, `app.exec_()` will need to be removed in many places, but it might also be useful to keep versions that can be run by a human for viewing the results).