### PR TITLE
Add manually-triggerable GitHub Action workflows for publishing to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,44 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag for OFFICIAL release'
+        required: true
+  # push:
+  #   tags:
+  #       - '*'
+
+jobs:
+  publish-pypi:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install tools
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Checkout tag ${{ github.event.inputs.tag }}
+      uses: actions/checkout@v2
+      with:
+          ref: ${{ github.event.inputs.tag }}
+
+    - name: Build source distribution and wheel
+      run: |
+        python setup.py sdist bdist_wheel
+
+    - name: List distribution artifacts
+      run: |
+        ls -l dist/
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.4.1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,45 @@
+name: Publish to TestPyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag for TEST release'
+        required: true
+  # push:
+  #   tags:
+  #       - '*'
+
+jobs:
+  publish-test-pypi:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install tools
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Checkout tag ${{ github.event.inputs.tag }}
+      uses: actions/checkout@v2
+      with:
+          ref: ${{ github.event.inputs.tag }}
+
+    - name: Build source distribution and wheel
+      run: |
+        python setup.py sdist bdist_wheel
+
+    - name: List distribution artifacts
+      run: |
+        ls -l dist/
+
+    - name: Publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@v1.4.1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
We will be able to run these workflows manually from the [GitHub Actions](https://github.com/NeuralEnsemble/ephyviewer/actions) page. For now, until I grow to trust it, I prefer triggering manually rather than on pushing a tag. Perhaps after the next release I will feel comfortable with it. 😁

@samuelgarcia, I think only you will be able to add the PyPI secret tokens to this repo. We are co-maintainers of the [official PyPI project](https://pypi.org/project/ephyviewer/), but only I am a maintainer of the [TestPyPI project](https://test.pypi.org/project/ephyviewer/) (I could add you if you like; you may need to create an account first). So, I've taken the initiative to generate tokens for both projects. I will email them to you so that you can add them to this repo's [GitHub secrets settings](https://github.com/NeuralEnsemble/ephyviewer/settings/secrets/actions).