### PR TITLE
Enable interactivity when running test_mainviewer.py manually

### DIFF
--- a/ephyviewer/tests/test_mainviewer.py
+++ b/ephyviewer/tests/test_mainviewer.py
@@ -102,6 +102,6 @@ def test_save_load_params(interactive=False):
 
 
 if __name__=='__main__':
-    test_mainviewer()
-    test_mainviewer2()
+    test_mainviewer(interactive=True)
+    test_mainviewer2(interactive=True)
     test_save_load_params(interactive=True)


### PR DESCRIPTION
Forgetting `interactive=True` for two tests was a mistake.