### PR TITLE
Use streams from Neo 0.10 in neosource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+/.idea

--- a/ephyviewer/datasource/neosource.py
+++ b/ephyviewer/datasource/neosource.py
@@ -231,7 +231,8 @@ class SpikeFromNeoRawIOSource(BaseSpikeSource):
 
     def get_chunk_by_time(self, chan=0,  t_start=None, t_stop=None):
         spike_timestamp = self.neorawio.get_spike_timestamps(block_index=self.block_index,
-                        seg_index=self.seg_index, unit_index=chan, t_start=t_start, t_stop=t_stop)
+                            seg_index=self.seg_index, spike_channel_index=chan,
+                            t_start=t_start, t_stop=t_stop)
 
         spike_times = self.neorawio.rescale_spike_timestamp(spike_timestamp, dtype='float64')
 

--- a/ephyviewer/datasource/neosource.py
+++ b/ephyviewer/datasource/neosource.py
@@ -108,15 +108,15 @@ class AnalogSignalFromNeoRawIOSource(BaseAnalogSignalSource):
         Initialize AnalogSignal sources from channels in NeoRawIO.
 
         :param neorawio: NeoRawIO to use
-        :param channel_indexes: list of channel indexes to use alone when Neo <= 0.9
-        :param stream_index: index of stream of signals when Neo > 0.9
+        :param channel_indexes: list of channel indexes to use when Neo < 0.10
+        :param stream_index: index of stream of signals when Neo >=0.10
         """
 
         BaseAnalogSignalSource.__init__(self)
         self.with_scatter = False
 
         self.neorawio = neorawio
-        if stream_index is None: # Neo <= 0.9 case
+        if stream_index is None: # Neo < 0.10 case
             self.has_streams = False
             if channel_indexes is None:
                 channel_indexes = slice(None)
@@ -124,7 +124,7 @@ class AnalogSignalFromNeoRawIOSource(BaseAnalogSignalSource):
             self.channels = self.neorawio.header['signal_channels'][channel_indexes]
             self.sample_rate = self.neorawio.get_signal_sampling_rate(
                 channel_indexes=self.channel_indexes)
-        else: # Neo > 0.9, with streams, case
+        else: # Neo > 0.10, with streams, case
             self.has_streams = True
             self.stream_index = stream_index
             stream_id = self.neorawio.header['signal_streams'][stream_index]['id']
@@ -312,7 +312,7 @@ def get_sources_from_neo_rawio(neorawio):
 
     #Signals
     try:
-        # Neo > 0.9.0 with streams of AnalogSignals
+        # Neo >= 0.10 with streams of AnalogSignals
         for si in range(0, neorawio.signal_streams_count()):
             sources['signal'].append(AnalogSignalFromNeoRawIOSource(neorawio,
                                                                     channel_indexes=None,
@@ -320,7 +320,7 @@ def get_sources_from_neo_rawio(neorawio):
 
     except AttributeError:
         if neorawio.signal_channels_count()>0:
-            try: # Neo = 0.9.0
+            try: # 0.9.0 <= Neo < 0.10
                 channel_indexes_list = neorawio.get_group_signal_channel_indexes()
 
             except AttributeError:


### PR DESCRIPTION
This is an alternative implementation to use the streams concept from Neo version 0.10. For AnalogSignalFromNeoRawIOSource it maintains an internal flag of whether the RawIO is using streams or not and expects a stream_index argument if so. It separately tracks the header['signal_channels'] which apply for the specified stream so that
channel_indexes then works as being those which are stream relative.