### PR TITLE
Make Neo RawIO sources compatible with Neo 0.6-0.10

### DIFF
--- a/ephyviewer/tests/test_datasource.py
+++ b/ephyviewer/tests/test_datasource.py
@@ -174,11 +174,11 @@ def test_spikeinterface_sources():
 
 
 if __name__=='__main__':
-    #~ test_InMemoryAnalogSignalSource()
-    #~ test_VideoMultiFileSource()
-    #~ test_InMemoryEventSource()
-    #~ test_InMemoryEpochSource()
-    #~ test_spikesource()
+    test_InMemoryAnalogSignalSource()
+    test_VideoMultiFileSource()
+    test_InMemoryEventSource()
+    test_InMemoryEpochSource()
+    test_spikesource()
     test_neo_rawio_sources()
-    #~ test_neo_object_sources()
-    #~ test_spikeinterface_sources()
+    test_neo_object_sources()
+    test_spikeinterface_sources()

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,6 @@
 av
 coveralls
-neo>=0.6.0
+neo>=0.10.0
 spikeinterface>=0.90.1
 pandas
 pytest

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,6 @@
 av
 coveralls
-neo>=0.10.0
+neo>=0.6.0
 spikeinterface>=0.90.1
 pandas
 pytest


### PR DESCRIPTION
Hi @samuelgarcia,

Here's my revised version of `neosource.py`. It should just work for all versions of Neo since RawIOs were introduced, back to Neo 0.6. I tested each major Neo release using [this Blackrock data set](https://gin.g-node.org/NeuralEnsemble/ephy_testing_data/src/master/blackrock/segment/PauseCorrect) with the `ephyviewer` CLI, as well as some of my own data sets in *neurotic*.

I don't see any reason at this point to limit support for Neo to 0.8+, since it's working for 0.6 and 0.7.

Tell me what you think!

Closes #158.