### PR TITLE
Prevent accidental un-docking of the navigation toolbar

### DIFF
--- a/ephyviewer/mainviewer.py
+++ b/ephyviewer/mainviewer.py
@@ -53,10 +53,11 @@ class MainViewer(QT.QMainWindow):
 
         self.navigation_toolbar = NavigationToolBar(**navigation_params)
 
-        dock = self.navigation_dock =  QT.QDockWidget('navigation',self)
-        dock.setObjectName( 'navigation')
+        dock = self.navigation_dock = QT.QDockWidget('navigation', self)
+        dock.setObjectName('navigation')
         dock.setWidget(self.navigation_toolbar)
-        dock.setTitleBarWidget(QT.QWidget())
+        dock.setTitleBarWidget(QT.QWidget())  # hide the widget title bar
+        dock.setFeatures(QT.DockWidget.NoDockWidgetFeatures)  # prevent accidental movement and undockingx
         self.addDockWidget(QT.TopDockWidgetArea, dock)
 
         self.navigation_toolbar.time_changed.connect(self.on_time_changed)


### PR DESCRIPTION
It was possible to accidentally grab an invisible 1-pixel-tall title bar for the navigation toolbar and drag it out of the main window, causing it to become un-docked, or to tabify it with viewers. This change prevents all movement of the navigation toolbar.