### PR TITLE
Compatibility with pyqt6

### DIFF
--- a/ephyviewer/base.py
+++ b/ephyviewer/base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #~ from __future__ import (unicode_literals, print_function, division, absolute_import)
 
-from .myqt import QT
+from .myqt import QT, QT_MODE
 import pyqtgraph as pg
 import numpy as np
 
@@ -58,14 +58,22 @@ class MyViewBox(pg.ViewBox):
         else:
             ev.ignore()
     def wheelEvent(self, ev, axis=None):
-        if ev.modifiers() == QT.Qt.ControlModifier:
+        if QT_MODE=="PyQt6":
+            modifier = QT.Qt.KeyboardModifier.ControlModifier
+        else:
+            modifier = QT.Qt.ControlModifier
+        if ev.modifiers() == modifier:
             z = 5. if ev.delta()>0 else 1/5.
         else:
             z = 1.1 if ev.delta()>0 else 1/1.1
         self.ygain_zoom.emit(z)
         ev.accept()
     def mouseDragEvent(self, ev, axis=None):
-        if ev.button()== QT.RightButton:
+        if QT_MODE=="PyQt6":
+            button = QT.MouseButton.RightButton
+        else:
+            button = QT.RightButton
+        if ev.button()== button:
             self.xsize_zoom.emit((ev.pos()-ev.lastPos()).x())
         else:
             pass
@@ -117,7 +125,10 @@ class BaseMultiChannelViewer(ViewerBase):
         if self.with_user_dialog and self._ControllerClass:
             self.all_params.blockSignals(True)
             self.params_controller = self._ControllerClass(parent=self, viewer=self)
-            self.params_controller.setWindowFlags(QT.Qt.Window)
+            if QT_MODE=="PyQt6":
+                self.params_controller.setWindowFlags(QT.Qt.WindowType.Window)
+            else:
+                self.params_controller.setWindowFlags(QT.Qt.Window)
             self.all_params.blockSignals(False)
         else:
             self.params_controller = None
@@ -250,7 +261,10 @@ class Base_MultiChannel_ParamController(Base_ParamController):
                 self.qlist = QT.QListWidget()
                 v.addWidget(self.qlist, 2)
                 self.qlist.addItems(names)
-                self.qlist.setSelectionMode(QT.QAbstractItemView.ExtendedSelection)
+                if QT_MODE=="PyQt6":
+                    self.qlist.setSelectionMode(QT.QAbstractItemView.SelectionMode.ExtendedSelection)
+                else:
+                    self.qlist.setSelectionMode(QT.QAbstractItemView.ExtendedSelection)
                 self.qlist.doubleClicked.connect(self.on_double_clicked)
 
                 for i in range(len(names)):

--- a/ephyviewer/dataframeview.py
+++ b/ephyviewer/dataframeview.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 
-from .myqt import QT
+from .myqt import QT, QT_MODE
 import pyqtgraph as pg
 
 from .base import ViewerBase
@@ -39,8 +39,11 @@ class DataFrameView(ViewerBase):
         self.mainlayout = QT.QVBoxLayout()
         self.setLayout(self.mainlayout)
 
-
-        self.qtable = QT.QTableWidget(selectionMode=QT.QAbstractItemView.SingleSelection,
+        if QT_MODE=="PyQt6":
+            self.qtable = QT.QTableWidget(selectionMode=QT.QAbstractItemView.SelectionMode.SingleSelection,
+                                                                            selectionBehavior=QT.QAbstractItemView.SelectionBehavior.SelectRows)
+        else:
+            self.qtable = QT.QTableWidget(selectionMode=QT.QAbstractItemView.SingleSelection,
                                                                             selectionBehavior=QT.QAbstractItemView.SelectRows)
         self.qtable.itemClicked.connect(self.on_selection_changed)
         self.mainlayout.addWidget(self.qtable)

--- a/ephyviewer/epochencoder.py
+++ b/ephyviewer/epochencoder.py
@@ -9,7 +9,7 @@ import numpy as np
 import matplotlib.cm
 import matplotlib.colors
 
-from .myqt import QT
+from .myqt import QT, QT_MODE
 from . import tools
 
 import pyqtgraph as pg
@@ -213,7 +213,10 @@ class EpochEncoder(ViewerBase):
         self.graphicsview.setCentralItem(self.plot)
 
         self.controls = QT.QWidget()
-        self.controls.setSizePolicy(QT.QSizePolicy.Preferred, QT.QSizePolicy.Fixed)
+        if QT_MODE=="PyQt6":
+            self.controls.setSizePolicy(QT.QSizePolicy.Policy.Preferred, QT.QSizePolicy.Policy.Fixed)
+        else:
+            self.controls.setSizePolicy(QT.QSizePolicy.Preferred, QT.QSizePolicy.Fixed)
         self.mainlayout.addWidget(self.controls)
 
         h = QT.QHBoxLayout()
@@ -246,7 +249,10 @@ class EpochEncoder(ViewerBase):
             if 'compactHeight' in spinbox.opts:  # pyqtgraph >= 0.11.0
                 spinbox.setOpts(compactHeight=False)
             range_group_box_layout.addWidget(spinbox, i, 1)
-            spinbox.setSizePolicy(QT.QSizePolicy.Preferred, QT.QSizePolicy.Preferred, )
+            if QT_MODE=="PyQt6":
+                spinbox.setSizePolicy(QT.QSizePolicy.Policy.Preferred, QT.QSizePolicy.Policy.Preferred, )
+            else:
+                spinbox.setSizePolicy(QT.QSizePolicy.Preferred, QT.QSizePolicy.Preferred, )
             spinbox.valueChanged.connect(self.on_spin_limit_changed)
             spinboxs.append(spinbox)
         self.spin_limit1, self.spin_limit2 = spinboxs
@@ -280,8 +286,12 @@ class EpochEncoder(ViewerBase):
 
         self.table_widget = QT.QTableWidget()
         h.addWidget(self.table_widget, stretch=1)
-        self.table_widget.setSelectionMode(QT.QAbstractItemView.SingleSelection)
-        self.table_widget.setSelectionBehavior(QT.QAbstractItemView.SelectRows)
+        if QT_MODE=="PyQt6":
+            self.table_widget.setSelectionMode(QT.QAbstractItemView.SelectionMode.SingleSelection)
+            self.table_widget.setSelectionBehavior(QT.QAbstractItemView.SelectionBehavior.SelectRows)
+        else:
+            self.table_widget.setSelectionMode(QT.QAbstractItemView.SingleSelection)
+            self.table_widget.setSelectionBehavior(QT.QAbstractItemView.SelectRows)
         self.table_widget.cellClicked.connect(self.on_table_cell_click)
         self.table_widget.cellChanged.connect(self.on_table_cell_change)
         self.table_widget_icons = {
@@ -294,13 +304,19 @@ class EpochEncoder(ViewerBase):
         # Toolbar
 
         self.toolbar = QT.QToolBar()
-        self.toolbar.setToolButtonStyle(QT.Qt.ToolButtonTextBesideIcon)
+        if QT_MODE=="PyQt6":
+            self.toolbar.setToolButtonStyle(QT.Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
+        else:
+            self.toolbar.setToolButtonStyle(QT.Qt.ToolButtonTextBesideIcon)
         self.toolbar.setIconSize(QT.QSize(16, 16))
         self.mainlayout.addWidget(self.toolbar)
 
         self.toggle_controls_visibility_action = self.toolbar.addAction('Hide controls', self.on_controls_visibility_changed)
         self.toggle_controls_visibility_button = self.toolbar.widgetForAction(self.toggle_controls_visibility_action)
-        self.toggle_controls_visibility_button.setArrowType(QT.UpArrow)
+        if QT_MODE=="PyQt6":
+            self.toggle_controls_visibility_button.setArrowType(QT.ArrowType.UpArrow)
+        else:
+            self.toggle_controls_visibility_button.setArrowType(QT.UpArrow)
 
         self.toolbar.addSeparator()
 
@@ -336,7 +352,10 @@ class EpochEncoder(ViewerBase):
 
     def make_param_controller(self):
         self.params_controller = EpochEncoder_ParamController(parent=self, viewer=self)
-        self.params_controller.setWindowFlags(QT.Qt.Window)
+        if QT_MODE=="PyQt6":
+            self.params_controller.setWindowFlags(QT.Qt.WindowType.Window)
+        else:
+            self.params_controller.setWindowFlags(QT.Qt.Window)
 
 
     def closeEvent(self, event):
@@ -385,11 +404,17 @@ class EpochEncoder(ViewerBase):
         if self.controls.isVisible():
             self.controls.hide()
             self.toggle_controls_visibility_action.setText('Show controls')
-            self.toggle_controls_visibility_button.setArrowType(QT.RightArrow)
+            if QT_MODE=="PyQt6":
+                self.toggle_controls_visibility_button.setArrowType(QT.ArrowType.RightArrow)
+            else:
+                self.toggle_controls_visibility_button.setArrowType(QT.RightArrow)
         else:
             self.controls.show()
             self.toggle_controls_visibility_action.setText('Hide controls')
-            self.toggle_controls_visibility_button.setArrowType(QT.UpArrow)
+            if QT_MODE=="PyQt6":
+                self.toggle_controls_visibility_button.setArrowType(QT.ArrowType.UpArrow)
+            else:
+                self.toggle_controls_visibility_button.setArrowType(QT.UpArrow)
 
     def show_params_controller(self):
         self.params_controller.show()

--- a/ephyviewer/mainviewer.py
+++ b/ephyviewer/mainviewer.py
@@ -14,17 +14,30 @@ from .epochviewer import EpochViewer
 from .eventlist import EventList
 from .spiketrainviewer import SpikeTrainViewer
 
-location_to_qt={
-    'left': QT.LeftDockWidgetArea,
-    'right': QT.RightDockWidgetArea,
-    'top': QT.TopDockWidgetArea,
-    'bottom': QT.BottomDockWidgetArea,
-}
+if QT_MODE == "PyQt6":
+    location_to_qt={
+        'left': QT.DockWidgetArea.LeftDockWidgetArea,
+        'right': QT.DockWidgetArea.RightDockWidgetArea,
+        'top': QT.DockWidgetArea.TopDockWidgetArea,
+        'bottom': QT.DockWidgetArea.BottomDockWidgetArea,
+    }
 
-orientation_to_qt={
-    'horizontal': QT.Horizontal,
-    'vertical': QT.Vertical,
-}
+    orientation_to_qt={
+        'horizontal': QT.Orientation.Horizontal,
+        'vertical': QT.Orientation.Vertical,
+    }
+else:
+    location_to_qt={
+        'left': QT.LeftDockWidgetArea,
+        'right': QT.RightDockWidgetArea,
+        'top': QT.TopDockWidgetArea,
+        'bottom': QT.BottomDockWidgetArea,
+    }
+
+    orientation_to_qt={
+        'horizontal': QT.Horizontal,
+        'vertical': QT.Vertical,
+    }
 
 
 
@@ -58,8 +71,12 @@ class MainViewer(QT.QMainWindow):
         dock.setObjectName('navigation')
         dock.setWidget(self.navigation_toolbar)
         dock.setTitleBarWidget(QT.QWidget())  # hide the widget title bar
-        dock.setFeatures(QT.DockWidget.NoDockWidgetFeatures)  # prevent accidental movement and undockingx
-        self.addDockWidget(QT.TopDockWidgetArea, dock)
+        if QT_MODE=="PyQt6":
+            dock.setFeatures(QT.DockWidget.DockWidgetFeature.NoDockWidgetFeatures)  # prevent accidental movement and undockingx
+            self.addDockWidget(QT.DockWidgetArea.TopDockWidgetArea, dock)
+        else:
+            dock.setFeatures(QT.DockWidget.NoDockWidgetFeatures)  # prevent accidental movement and undockingx
+            self.addDockWidget(QT.TopDockWidgetArea, dock)
 
         self.navigation_toolbar.time_changed.connect(self.on_time_changed)
         self.navigation_toolbar.xsize_changed.connect(self.on_xsize_changed)

--- a/ephyviewer/navigation.py
+++ b/ephyviewer/navigation.py
@@ -183,7 +183,10 @@ class NavigationToolBar(QT.QWidget) :
             self.label_datetime = QT.QLabel('')
             h.addWidget(self.label_datetime)
             #trick for separator
-            h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
+            if QT_MODE=="PyQt6":
+                h.addWidget(QT.QFrame(frameShape=QT.QFrame.Shape.VLine, frameShadow=QT.QFrame.Shadow.Sunken))
+            else:
+                h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
 
         if show_global_xsize:
             h.addWidget(QT.QLabel('Time width (s):'))

--- a/ephyviewer/navigation.py
+++ b/ephyviewer/navigation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #~ from __future__ import (unicode_literals, print_function, division, absolute_import)
 
-from .myqt import QT
+from .myqt import QT, QT_MODE
 import pyqtgraph as pg
 import numpy as np
 
@@ -31,7 +31,10 @@ class NavigationToolBar(QT.QWidget) :
 
         QT.QWidget.__init__(self, parent)
 
-        self.setSizePolicy(QT.QSizePolicy.Minimum, QT.QSizePolicy.Maximum)
+        if QT_MODE == "PyQt6":
+            self.setSizePolicy(QT.QSizePolicy.Policy.Minimum, QT.QSizePolicy.Policy.Maximum)
+        else:
+            self.setSizePolicy(QT.QSizePolicy.Minimum, QT.QSizePolicy.Maximum)
 
         self.mainlayout = QT.QVBoxLayout()
         self.setLayout(self.mainlayout)
@@ -56,7 +59,10 @@ class NavigationToolBar(QT.QWidget) :
 
         if show_scroll_time:
             #~ self.slider = QSlider()
-            self.scroll_time = QT.QScrollBar(orientation=QT.Horizontal, minimum=0, maximum=1000)
+            if QT_MODE == "PyQt6":
+                self.scroll_time = QT.QScrollBar(orientation=QT.Orientation.Horizontal, minimum=0, maximum=1000)
+            else:
+                self.scroll_time = QT.QScrollBar(orientation=QT.Horizontal, minimum=0, maximum=1000)
             self.mainlayout.addWidget(self.scroll_time)
             self.scroll_time.valueChanged.connect(self.on_scroll_time_changed)
 
@@ -92,7 +98,10 @@ class NavigationToolBar(QT.QWidget) :
             self.speed = 1.
 
             #trick for separator
-            h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
+            if QT_MODE=="PyQt6":
+                h.addWidget(QT.QFrame(frameShape=QT.QFrame.Shape.VLine, frameShadow=QT.QFrame.Shadow.Sunken))
+            else:
+                h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
 
             # add spacebar shortcut for play/pause
             play_pause_shortcut = QT.QShortcut(self)
@@ -119,19 +128,34 @@ class NavigationToolBar(QT.QWidget) :
             h.addWidget(but)
 
             #trick for separator
-            h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
+            if QT_MODE=="PyQt6":
+                h.addWidget(QT.QFrame(frameShape=QT.QFrame.Shape.VLine, frameShadow=QT.QFrame.Shadow.Sunken))
+            else:
+                h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
 
             # add shortcuts for stepping through time and changing step size
-            shortcuts = [
-                {'key': QT.Qt.Key_Left,  'callback': self.prev_step},
-                {'key': QT.Qt.Key_Right, 'callback': self.next_step},
-                {'key': QT.Qt.Key_Up,    'callback': self.increase_step},
-                {'key': QT.Qt.Key_Down,  'callback': self.decrease_step},
-                {'key': 'a',             'callback': self.prev_step},
-                {'key': 'd',             'callback': self.next_step},
-                {'key': 'w',             'callback': self.increase_step},
-                {'key': 's',             'callback': self.decrease_step},
-            ]
+            if QT_MODE=="PyQt6":
+                shortcuts = [
+                    {'key': QT.Qt.Key.Key_Left,  'callback': self.prev_step},
+                    {'key': QT.Qt.Key.Key_Right, 'callback': self.next_step},
+                    {'key': QT.Qt.Key.Key_Up,    'callback': self.increase_step},
+                    {'key': QT.Qt.Key.Key_Down,  'callback': self.decrease_step},
+                    {'key': 'a',             'callback': self.prev_step},
+                    {'key': 'd',             'callback': self.next_step},
+                    {'key': 'w',             'callback': self.increase_step},
+                    {'key': 's',             'callback': self.decrease_step},
+                ]
+            else:
+                shortcuts = [
+                    {'key': QT.Qt.Key_Left,  'callback': self.prev_step},
+                    {'key': QT.Qt.Key_Right, 'callback': self.next_step},
+                    {'key': QT.Qt.Key_Up,    'callback': self.increase_step},
+                    {'key': QT.Qt.Key_Down,  'callback': self.decrease_step},
+                    {'key': 'a',             'callback': self.prev_step},
+                    {'key': 'd',             'callback': self.next_step},
+                    {'key': 'w',             'callback': self.increase_step},
+                    {'key': 's',             'callback': self.decrease_step},
+                ]
             for s in shortcuts:
                 shortcut = QT.QShortcut(self)
                 shortcut.setKey(QT.QKeySequence(s['key']))
@@ -145,7 +169,10 @@ class NavigationToolBar(QT.QWidget) :
                 self.spinbox_time.setOpts(compactHeight=False)
             h.addWidget(self.spinbox_time)
             #trick for separator
-            h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
+            if QT_MODE=="PyQt6":
+                h.addWidget(QT.QFrame(frameShape=QT.QFrame.Shape.VLine, frameShadow=QT.QFrame.Shadow.Sunken))
+            else:
+                h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
 
 
             #~ h.addSeparator()
@@ -167,7 +194,10 @@ class NavigationToolBar(QT.QWidget) :
             #~ self.spinbox_xsize.valueChanged.connect(self.on_spinbox_xsize_changed)
             self.spinbox_xsize.valueChanged.connect(self.xsize_changed.emit)
             #trick for separator
-            h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
+            if QT_MODE=="PyQt6":
+                h.addWidget(QT.QFrame(frameShape=QT.QFrame.Shape.VLine, frameShadow=QT.QFrame.Shadow.Sunken))
+            else:
+                h.addWidget(QT.QFrame(frameShape=QT.QFrame.VLine, frameShadow=QT.QFrame.Sunken))
 
         if show_auto_scale:
             but = QT.PushButton('Auto scale')

--- a/ephyviewer/standalone.py
+++ b/ephyviewer/standalone.py
@@ -83,7 +83,10 @@ class WindowManager():
         self.windows.append(win)
 
         # delete window on close so that memory and file resources are released
-        win.setAttribute(QT.WA_DeleteOnClose, True)
+        if QT_MODE=="PyQt6":
+            win.setAttribute(QT.WidgetAttribute.WA_DeleteOnClose, True)
+        else:
+            win.setAttribute(QT.WA_DeleteOnClose, True)
         win.destroyed.connect(
             lambda *args, i=len(self.windows)-1: self.free_resources(i))
 
@@ -229,16 +232,28 @@ class RawNeoOpenDialog(QT.QDialog):
         #~ print('on_addfiles')
         #~ print(self.neo_rawio_class)
         #~ print(self.neo_rawio_class.rawmode)
+        if QT_MODE=="PyQt6":
+            if self.neo_rawio_class.rawmode.endswith('-file'):
+                fd = QT.QFileDialog(fileMode=QT.QFileDialog.FileMode.ExistingFiles, acceptMode=QT.QFileDialog.AcceptMode.AcceptOpen)
+                #Todo play with rawio.extentsions
+                fd.setNameFilters(['All (*)'])
+            elif self.neo_rawio_class.rawmode.endswith('-dir'):
+                fd = QT.QFileDialog(fileMode=QT.QFileDialog.FileMode.DirectoryOnly, acceptMode=QT.QFileDialog.AcceptMode.AcceptOpen)
+                #~ fd.setNameFilters(['All (*)'])
+            fd.setViewMode(QT.QFileDialog.ViewMode.Detail)
+            if fd.exec_():
+                filenames = fd.selectedFiles()
+                self.list_files.addItems(filenames)
+        else:
+            if self.neo_rawio_class.rawmode.endswith('-file'):
+                fd = QT.QFileDialog(fileMode=QT.QFileDialog.ExistingFiles, acceptMode=QT.QFileDialog.AcceptOpen)
+                #Todo play with rawio.extentsions
+                fd.setNameFilters(['All (*)'])
+            elif self.neo_rawio_class.rawmode.endswith('-dir'):
+                fd = QT.QFileDialog(fileMode=QT.QFileDialog.DirectoryOnly, acceptMode=QT.QFileDialog.AcceptOpen)
+                #~ fd.setNameFilters(['All (*)'])
 
-        if self.neo_rawio_class.rawmode.endswith('-file'):
-            fd = QT.QFileDialog(fileMode=QT.QFileDialog.ExistingFiles, acceptMode=QT.QFileDialog.AcceptOpen)
-            #Todo play with rawio.extentsions
-            fd.setNameFilters(['All (*)'])
-        elif self.neo_rawio_class.rawmode.endswith('-dir'):
-            fd = QT.QFileDialog(fileMode=QT.QFileDialog.DirectoryOnly, acceptMode=QT.QFileDialog.AcceptOpen)
-            #~ fd.setNameFilters(['All (*)'])
-
-        fd.setViewMode(QT.QFileDialog.Detail)
-        if fd.exec_():
-            filenames = fd.selectedFiles()
-            self.list_files.addItems(filenames)
+            fd.setViewMode(QT.QFileDialog.Detail)
+            if fd.exec_():
+                filenames = fd.selectedFiles()
+                self.list_files.addItems(filenames)


### PR DESCRIPTION
Hello (salut Sam!!)
I have added compatibility for pyqt6 since it is the version I use. It now works with my (so far very basic) usage of the library. I guess you had it commented as a possible QT_MODE because of the slightly different structure of some enums. For those (I have tried to be extensive, yet I might have missed a few), I used QT_MODE as a condition to access the right variable "path".
However, I couldn't successfully run the included pytests, as it fails quickly at the test for Neo rawio sources. I assume I don't have the right test files so I didn't worry much about this.
Please consider including the PyQt6 compatibility for your next release of the package. 
All the best