### PR TITLE
Replace deprecated matplotlib get_cmap()

### DIFF
--- a/ephyviewer/base.py
+++ b/ephyviewer/base.py
@@ -324,7 +324,7 @@ class Base_MultiChannel_ParamController(Base_ParamController):
         cmap_name = str(self.combo_cmap.currentText())
         n = np.sum(self.selected)
         if n==0: return
-        cmap = matplotlib.colormaps[cmap_name]
+        cmap = matplotlib.colormaps[cmap_name].resampled(n)
 
         self.viewer.by_channel_params.blockSignals(True)
         for i, c in enumerate(np.nonzero(self.selected)[0]):

--- a/ephyviewer/base.py
+++ b/ephyviewer/base.py
@@ -324,7 +324,7 @@ class Base_MultiChannel_ParamController(Base_ParamController):
         cmap_name = str(self.combo_cmap.currentText())
         n = np.sum(self.selected)
         if n==0: return
-        cmap = matplotlib.cm.get_cmap(cmap_name , n)
+        cmap = matplotlib.colormaps[cmap_name]
 
         self.viewer.by_channel_params.blockSignals(True)
         for i, c in enumerate(np.nonzero(self.selected)[0]):

--- a/ephyviewer/datasource/epochs.py
+++ b/ephyviewer/datasource/epochs.py
@@ -86,7 +86,7 @@ class WritableEpochSource(InMemoryEpochSource):
         # TODO: colors should be managed directly by EpochEncoder
         if color_labels is None:
             n = len(self.possible_labels)
-            cmap = matplotlib.cm.get_cmap('Dark2' , n)
+            cmap = matplotlib.colormaps['Dark2']
             color_labels = [ matplotlib.colors.ColorConverter().to_rgb(cmap(i)) for i in  range(n)]
             color_labels = (np.array(color_labels)*255).astype(int)
             color_labels = color_labels.tolist()

--- a/ephyviewer/datasource/epochs.py
+++ b/ephyviewer/datasource/epochs.py
@@ -86,7 +86,7 @@ class WritableEpochSource(InMemoryEpochSource):
         # TODO: colors should be managed directly by EpochEncoder
         if color_labels is None:
             n = len(self.possible_labels)
-            cmap = matplotlib.colormaps['Dark2']
+            cmap = matplotlib.colormaps['Dark2'].resampled(n)
             color_labels = [ matplotlib.colors.ColorConverter().to_rgb(cmap(i)) for i in  range(n)]
             color_labels = (np.array(color_labels)*255).astype(int)
             color_labels = color_labels.tolist()

--- a/ephyviewer/datasource/signals.py
+++ b/ephyviewer/datasource/signals.py
@@ -85,7 +85,7 @@ class AnalogSignalSourceWithScatter(InMemoryAnalogSignalSource):
         if self.scatter_colors is None:
             self.scatter_colors = {}
             n = len(self._labels)
-            colors = matplotlib.cm.get_cmap('Accent', n)
+            colors = matplotlib.colormaps['Accent']
             for i,k in enumerate(self._labels):
                 self.scatter_colors[k] = matplotlib.colors.to_hex(colors(i))
 

--- a/ephyviewer/datasource/signals.py
+++ b/ephyviewer/datasource/signals.py
@@ -85,7 +85,7 @@ class AnalogSignalSourceWithScatter(InMemoryAnalogSignalSource):
         if self.scatter_colors is None:
             self.scatter_colors = {}
             n = len(self._labels)
-            colors = matplotlib.colormaps['Accent']
+            colors = matplotlib.colormaps['Accent'].resampled(n)
             for i,k in enumerate(self._labels):
                 self.scatter_colors[k] = matplotlib.colors.to_hex(colors(i))
 

--- a/ephyviewer/spectrogramviewer.py
+++ b/ephyviewer/spectrogramviewer.py
@@ -293,7 +293,7 @@ class SpectrogramViewer(BaseMultiChannelViewer):
     def change_color_scale(self):
         N = 512
         cmap_name = self.params['colormap']
-        cmap = matplotlib.colormaps[cmap_name]
+        cmap = matplotlib.colormaps[cmap_name].resampled(N)
 
         lut = []
         for i in range(N):

--- a/ephyviewer/spectrogramviewer.py
+++ b/ephyviewer/spectrogramviewer.py
@@ -293,7 +293,7 @@ class SpectrogramViewer(BaseMultiChannelViewer):
     def change_color_scale(self):
         N = 512
         cmap_name = self.params['colormap']
-        cmap = matplotlib.cm.get_cmap(cmap_name , N)
+        cmap = matplotlib.colormaps[cmap_name]
 
         lut = []
         for i in range(N):

--- a/ephyviewer/timefreqviewer.py
+++ b/ephyviewer/timefreqviewer.py
@@ -377,7 +377,7 @@ class TimeFreqViewer(BaseMultiChannelViewer):
     def change_color_scale(self):
         N = 512
         cmap_name = self.params['colormap']
-        cmap = matplotlib.colormaps[cmap_name]
+        cmap = matplotlib.colormaps[cmap_name].resampled(N)
 
         lut = []
         for i in range(N):

--- a/ephyviewer/timefreqviewer.py
+++ b/ephyviewer/timefreqviewer.py
@@ -377,7 +377,7 @@ class TimeFreqViewer(BaseMultiChannelViewer):
     def change_color_scale(self):
         N = 512
         cmap_name = self.params['colormap']
-        cmap = matplotlib.cm.get_cmap(cmap_name , N)
+        cmap = matplotlib.colormaps[cmap_name]
 
         lut = []
         for i in range(N):


### PR DESCRIPTION
The function has been removed from matplotlib >= 3.9.
Fixes #184
